### PR TITLE
ExpirationFilter

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,15 +55,6 @@ func (f *ResponseFuture) Cancel() {
 // Only use this if you need to do something custom at the transport level.
 func HttpService(c *http.Client) Service {
 	return Service(func(req Request) Response {
-		// Check if the context is already cancelled. If it is, there's no point
-		// making the client request.
-		select {
-		case <-req.Context.Done():
-			return Response{
-				Error: terrors.Timeout("cancelled", "Request already cancelled", nil)}
-		default:
-		}
-
 		httpRsp, err := c.Do(req.Request.WithContext(req.Context))
 		// Read the response in its entirety and close the Response body here; this protects us from callers that forget to
 		// call Close() but does not allow streaming responses.

--- a/http.go
+++ b/http.go
@@ -1,0 +1,58 @@
+package typhon
+
+import (
+	"context"
+	"io"
+	"net/http"
+
+	log "github.com/monzo/slog"
+)
+
+func HttpHandler(svc Service) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, httpReq *http.Request) {
+		ctx, cancel := context.WithCancel(httpReq.Context())
+		defer cancel() // if already cancelled on escape, this is a no-op
+
+		// If the ResponseWriter is a CloseNotifier, propagate the cancellation downward via the context
+		if cn, ok := rw.(http.CloseNotifier); ok {
+			closed := cn.CloseNotify()
+			go func() {
+				select {
+				case <-ctx.Done():
+				case <-closed:
+					cancel()
+				}
+			}()
+		}
+
+		if httpReq.Body != nil {
+			defer httpReq.Body.Close()
+		}
+
+		req := Request{
+			Context: ctx,
+			Request: *httpReq}
+		rsp := svc(req)
+
+		// Write the response out to the wire
+		for k, v := range rsp.Header {
+			if k == "Content-Length" {
+				continue
+			}
+			rw.Header()[k] = v
+		}
+		rw.WriteHeader(rsp.StatusCode)
+		if rsp.Body != nil {
+			defer rsp.Body.Close()
+			if _, err := io.Copy(rw, rsp.Body); err != nil {
+				log.Error(req, "Error copying response body: %v", err)
+			}
+		}
+	})
+}
+
+func HttpServer(svc Service) *http.Server {
+	return &http.Server{
+		Handler:        HttpHandler(svc),
+		MaxHeaderBytes: http.DefaultMaxHeaderBytes}
+}

--- a/router_test.go
+++ b/router_test.go
@@ -41,6 +41,8 @@ func TestRouter(t *testing.T) {
 }
 
 func TestRouter_CatchallPath(t *testing.T) {
+	t.Parallel()
+
 	// Registering a global handler should apply to all paths
 	router := NewRouter()
 	router.GET("/*residual", func(req Request) Response {

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -1,6 +1,7 @@
 package typhon
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,17 +10,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTimeout(t *testing.T) {
+func TestTimeoutFilter(t *testing.T) {
 	t.Parallel()
 	// A Service which does not time out should be unmolested
 	svc := Service(func(req Request) Response {
 		return Response{}
 	})
-	svc = svc.Filter(TimeoutFilter(10 * time.Second))
+	svc = svc.Filter(TimeoutFilter(time.Second))
 	rsp := svc(NewRequest(nil, "GET", "/", nil))
 	assert.NoError(t, rsp.Error)
 
-	// One which does should timeout with the default timeout
+	// One which does should time out
 	svc = Service(func(req Request) Response {
 		time.Sleep(50 * time.Millisecond)
 		return Response{}
@@ -28,14 +29,24 @@ func TestTimeout(t *testing.T) {
 	rsp = svc(NewRequest(nil, "GET", "/", nil))
 	require.Error(t, rsp.Error)
 	assert.True(t, terrors.Wrap(rsp.Error, nil).(*terrors.Error).Matches(terrors.ErrTimeout))
+}
 
-	// …or the one in the request if one was specified
-	req := NewRequest(nil, "GET", "/", nil)
-	req.Header.Set("Timeout", "100") // 100 milliseconds
-	rsp = svc(req)
-	assert.NoError(t, rsp.Error)
-	req.Header.Set("Timeout", "5")
-	rsp = svc(NewRequest(nil, "GET", "/", nil))
+func TestExpirationFilter(t *testing.T) {
+	t.Parallel()
+
+	svc := Service(func(req Request) Response {
+		return req.Response("ok")
+	})
+	svc = svc.Filter(ExpirationFilter)
+
+	ctx, ccl := context.WithCancel(context.Background())
+	ccl()
+	req := NewRequest(ctx, "GET", "/", nil)
+	rsp := svc(req)
+
 	require.Error(t, rsp.Error)
-	assert.True(t, terrors.Wrap(rsp.Error, nil).(*terrors.Error).Matches(terrors.ErrTimeout))
+	terr := terrors.Wrap(rsp.Error, nil).(*terrors.Error)
+	terrExpect := terrors.BadRequest("expired", "Request has expired", nil)
+	assert.Equal(t, terrExpect.Message, terr.Message)
+	assert.Equal(t, terrExpect.Code, terr.Code)
 }


### PR DESCRIPTION
* `ExpirationFilter`: An admission control filter which rejects requests if they are already cancelled
* Removed the timeout override functionality from `TimeoutFilter`; I suspect it is causing some issues, and in general shouldn't be used.