### PR TITLE
Don't chunk non-streaming request bodies 🎁

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.8.x
   - 1.9.x
+  - 1.10.x
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin

--- a/buffer.go
+++ b/buffer.go
@@ -38,3 +38,16 @@ func (s *streamer) Write(p []byte) (int, error) {
 func (s *streamer) Close() error {
 	return s.pipeW.Close()
 }
+
+// countingWriter is a writer which proxies writes to an underlying io.Writer, keeping track of how many bytes have
+// been written in total
+type countingWriter struct {
+	n int
+	io.Writer
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.Writer.Write(p)
+	c.n += n
+	return n, err
+}


### PR DESCRIPTION
For small requests it is not desirable to chunk the body as it means intermediary proxies (like linkerd) cannot retry the request transparently.

Go's logic for deciding when to chunk a request is subtle and a bit [magic](https://github.com/golang/go/blob/26708439ecb4dc923149b17eb522df46dcc2fb23/src/net/http/transfer.go#L150-L186), but this prevents chunking behaviour when `Encode()` is called before sending the response off.