### PR TITLE
Fix leak when infinite contexts are used to make requests 🚰

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -3,6 +3,7 @@ package typhon
 import (
 	"bytes"
 	"io"
+	"sync"
 )
 
 type bufCloser struct {
@@ -46,8 +47,36 @@ type countingWriter struct {
 	io.Writer
 }
 
-func (c *countingWriter) Write(p []byte) (int, error) {
-	n, err := c.Writer.Write(p)
-	c.n += n
+func (w *countingWriter) Write(p []byte) (int, error) {
+	n, err := w.Writer.Write(p)
+	w.n += n
+	return n, err
+}
+
+// doneReader is a wrapper around a ReadCloser which provides notification when the stream has been fully consumed
+// (ie. when EOF is reached, or when the reader is closed.)
+type doneReader struct {
+	done     chan struct{}
+	doneOnce sync.Once
+	io.ReadCloser
+}
+
+func newDoneReader(r io.ReadCloser) *doneReader {
+	return &doneReader{
+		done:       make(chan struct{}),
+		ReadCloser: r}
+}
+
+func (r *doneReader) Close() error {
+	err := r.ReadCloser.Close()
+	r.doneOnce.Do(func() { close(r.done) })
+	return err
+}
+
+func (r *doneReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if err == io.EOF {
+		r.doneOnce.Do(func() { close(r.done) })
+	}
 	return n, err
 }

--- a/client.go
+++ b/client.go
@@ -50,10 +50,14 @@ func HttpService(rt http.RoundTripper) Service {
 		// When the calling context is cancelled, close the response body
 		// This protects callers that forget to call Close(), or those which proxy responses upstream
 		if httpRsp != nil && httpRsp.Body != nil {
-			body := httpRsp.Body
+			dr := newDoneReader(httpRsp.Body)
+			httpRsp.Body = dr
 			go func() {
-				<-req.Done()
-				body.Close()
+				select {
+				case <-dr.done:
+				case <-req.Done():
+					dr.Close()
+				}
 			}()
 		}
 		return Response{

--- a/client.go
+++ b/client.go
@@ -50,14 +50,14 @@ func HttpService(rt http.RoundTripper) Service {
 		// When the calling context is cancelled, close the response body
 		// This protects callers that forget to call Close(), or those which proxy responses upstream
 		if httpRsp != nil && httpRsp.Body != nil {
-			dr := newDoneReader(httpRsp.Body)
-			httpRsp.Body = dr
+			body := newDoneReader(httpRsp.Body)
+			httpRsp.Body = body
 			go func() {
 				select {
-				case <-dr.done:
+				case <-body.done:
 				case <-req.Done():
-					dr.Close()
 				}
+				body.Close()
 			}()
 		}
 		return Response{

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1,14 +1,17 @@
 package typhon
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/facebookgo/httpcontrol"
+	"github.com/fortytw2/leaktest"
 	"github.com/monzo/terrors"
 	"github.com/stretchr/testify/suite"
 )
@@ -37,6 +40,10 @@ func (suite *e2eSuite) serve(svc Service) Server {
 }
 
 func (suite *e2eSuite) TestStraightforward() {
+	defer leaktest.Check(suite.T())()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	svc := Service(func(req Request) Response {
 		// Simple requests like this shouldn't be chunked
 		suite.Assert().NotContains(req.TransferEncoding, "chunked")
@@ -48,7 +55,7 @@ func (suite *e2eSuite) TestStraightforward() {
 	s := suite.serve(svc)
 	defer s.Stop()
 
-	req := NewRequest(nil, "GET", fmt.Sprintf("http://%s", s.Listener().Addr()), map[string]string{
+	req := NewRequest(ctx, "GET", fmt.Sprintf("http://%s", s.Listener().Addr()), map[string]string{
 		"a": "b"})
 	rsp := req.Send().Response()
 	suite.Require().NoError(rsp.Error)
@@ -59,6 +66,10 @@ func (suite *e2eSuite) TestStraightforward() {
 }
 
 func (suite *e2eSuite) TestDomainSocket() {
+	defer leaktest.Check(suite.T())()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	svc := Service(func(req Request) Response {
 		return NewResponse(req)
 	})
@@ -79,13 +90,17 @@ func (suite *e2eSuite) TestDomainSocket() {
 		Dial: func(network, address string) (net.Conn, error) {
 			return net.DialUnix("unix", nil, addr)
 		}}
-	req := NewRequest(nil, "GET", "http://localhost/foo", nil)
+	req := NewRequest(ctx, "GET", "http://localhost/foo", nil)
 	rsp := req.SendVia(HttpService(sockTransport)).Response()
 	suite.Require().NoError(rsp.Error)
 	suite.Assert().Equal(http.StatusOK, rsp.StatusCode)
 }
 
 func (suite *e2eSuite) TestError() {
+	defer leaktest.Check(suite.T())()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	expectedErr := terrors.Unauthorized("ah_ah_ah", "You didn't say the magic word!", map[string]string{
 		"param": "value"})
 	svc := Service(func(req Request) Response {
@@ -98,7 +113,7 @@ func (suite *e2eSuite) TestError() {
 	s := suite.serve(svc)
 	defer s.Stop()
 
-	req := NewRequest(nil, "GET", fmt.Sprintf("http://%s", s.Listener().Addr()), nil)
+	req := NewRequest(ctx, "GET", fmt.Sprintf("http://%s", s.Listener().Addr()), nil)
 	rsp := req.Send().Response()
 	suite.Assert().Equal(http.StatusUnauthorized, rsp.StatusCode)
 
@@ -114,6 +129,10 @@ func (suite *e2eSuite) TestError() {
 }
 
 func (suite *e2eSuite) TestCancellation() {
+	defer leaktest.Check(suite.T())()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	cancelled := make(chan struct{})
 	svc := Service(func(req Request) Response {
 		<-req.Done()
@@ -124,7 +143,7 @@ func (suite *e2eSuite) TestCancellation() {
 	s := suite.serve(svc)
 	defer s.Stop()
 
-	req := NewRequest(nil, "GET", fmt.Sprintf("http://%s/", s.Listener().Addr()), nil)
+	req := NewRequest(ctx, "GET", fmt.Sprintf("http://%s/", s.Listener().Addr()), nil)
 	f := req.Send()
 	select {
 	case <-cancelled:
@@ -140,6 +159,10 @@ func (suite *e2eSuite) TestCancellation() {
 }
 
 func (suite *e2eSuite) TestNoFollowRedirect() {
+	defer leaktest.Check(suite.T())()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	svc := Service(func(req Request) Response {
 		if req.URL.Path == "/redirected" {
 			return req.Response("😱")
@@ -152,13 +175,17 @@ func (suite *e2eSuite) TestNoFollowRedirect() {
 	})
 	s := suite.serve(svc)
 	defer s.Stop()
-	req := NewRequest(nil, "GET", fmt.Sprintf("http://%s/", s.Listener().Addr()), nil)
+	req := NewRequest(ctx, "GET", fmt.Sprintf("http://%s/", s.Listener().Addr()), nil)
 	rsp := req.Send().Response()
 	suite.Assert().NoError(rsp.Error)
 	suite.Assert().Equal(http.StatusFound, rsp.StatusCode)
 }
 
 func (suite *e2eSuite) TestProxiedStreamer() {
+	defer leaktest.Check(suite.T())()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	chunks := make(chan bool, 2)
 	chunks <- true
 	downstream := Service(func(req Request) Response {
@@ -179,13 +206,13 @@ func (suite *e2eSuite) TestProxiedStreamer() {
 	defer s.Stop()
 
 	proxy := Service(func(req Request) Response {
-		proxyReq := NewRequest(nil, "GET", fmt.Sprintf("http://%s/", s.Listener().Addr()), nil)
+		proxyReq := NewRequest(req, "GET", fmt.Sprintf("http://%s/", s.Listener().Addr()), nil)
 		return proxyReq.Send().Response()
 	})
 	ps := suite.serve(proxy)
 	defer ps.Stop()
 
-	req := NewRequest(nil, "GET", fmt.Sprintf("http://%s/", ps.Listener().Addr()), nil)
+	req := NewRequest(ctx, "GET", fmt.Sprintf("http://%s/", ps.Listener().Addr()), nil)
 	rsp := req.Send().Response()
 	suite.Assert().NoError(rsp.Error)
 	suite.Assert().Equal(http.StatusOK, rsp.StatusCode)
@@ -202,4 +229,27 @@ func (suite *e2eSuite) TestProxiedStreamer() {
 		chunks <- true
 	}
 	close(chunks)
+}
+
+// TestInfiniteContext verifies that Typhon does not leak a Goroutine if an infinite context (one that isn't cancelled
+// is used to make a request)
+func (suite *e2eSuite) TestInfiniteContext() {
+	defer leaktest.Check(suite.T())()
+	ctx := context.Background()
+
+	svc := Service(func(req Request) Response {
+		return req.Response(map[string]string{
+			"b": "a"})
+	})
+	svc = svc.Filter(ErrorFilter)
+	s := suite.serve(svc)
+	defer s.Stop()
+
+	req := NewRequest(ctx, "GET", fmt.Sprintf("http://%s", s.Listener().Addr()), map[string]string{
+		"a": "b"})
+	rsp := req.Send().Response()
+	suite.Require().NoError(rsp.Error)
+	suite.Assert().Equal(http.StatusOK, rsp.StatusCode)
+
+	ioutil.ReadAll(rsp.Body) // Consume the body (after which the request should be auto-closed)
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -231,8 +231,8 @@ func (suite *e2eSuite) TestProxiedStreamer() {
 	close(chunks)
 }
 
-// TestInfiniteContext verifies that Typhon does not leak a Goroutine if an infinite context (one that isn't cancelled
-// is used to make a request)
+// TestInfiniteContext verifies that Typhon does not leak Goroutines if an infinite context (one that's never calcelled)
+// is used to make a request.
 func (suite *e2eSuite) TestInfiniteContext() {
 	defer leaktest.Check(suite.T())()
 	ctx := context.Background()

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -231,7 +231,7 @@ func (suite *e2eSuite) TestProxiedStreamer() {
 	close(chunks)
 }
 
-// TestInfiniteContext verifies that Typhon does not leak Goroutines if an infinite context (one that's never calcelled)
+// TestInfiniteContext verifies that Typhon does not leak Goroutines if an infinite context (one that's never cancelled)
 // is used to make a request.
 func (suite *e2eSuite) TestInfiniteContext() {
 	defer leaktest.Check(suite.T())()


### PR DESCRIPTION
Previously when a caller used an infinite context (eg. `context.Background()`) to make a request, this would cause a resource leak as Typhon was waiting for the context to be cancelled to `Close()` the body.

This change ensures request bodies are additionally closed when they are fully read, and adds tests to ensure no goroutines are leaked.