### PR TITLE
Context handling

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -76,7 +76,7 @@ func (r *doneReader) Close() error {
 func (r *doneReader) Read(p []byte) (int, error) {
 	n, err := r.ReadCloser.Read(p)
 	if err == io.EOF {
-		r.closedOnce.Do(func() { close(r.closed) })
+		r.Close()
 	}
 	return n, err
 }

--- a/client.go
+++ b/client.go
@@ -43,7 +43,8 @@ func (f *ResponseFuture) Response() Response {
 // Only use this if you need to do something custom at the transport level.
 func HttpService(rt http.RoundTripper) Service {
 	return Service(func(req Request) Response {
-		httpRsp, err := rt.RoundTrip(req.Request.WithContext(req.Context))
+		ctx := req.unwrappedContext()
+		httpRsp, err := rt.RoundTrip(req.Request.WithContext(ctx))
 		// When the calling context is cancelled, close the response body
 		// This protects callers that forget to call Close(), or those which proxy responses upstream
 		if httpRsp != nil && httpRsp.Body != nil {

--- a/client.go
+++ b/client.go
@@ -42,7 +42,7 @@ func (f *ResponseFuture) Response() Response {
 // HttpService returns a Service which sends requests via the given net/http RoundTripper.
 // Only use this if you need to do something custom at the transport level.
 func HttpService(rt http.RoundTripper) Service {
-	return Service(func(req Request) Response {
+	return func(req Request) Response {
 		ctx := req.unwrappedContext()
 		httpRsp, err := rt.RoundTrip(req.Request.WithContext(ctx))
 		// When the calling context is cancelled, close the response body
@@ -61,7 +61,7 @@ func HttpService(rt http.RoundTripper) Service {
 		return Response{
 			Response: httpRsp,
 			Error:    terrors.Wrap(err, nil)}
-	})
+	}
 }
 
 // BareClient is the most basic way to send a request, using the default http RoundTripper

--- a/filter.go
+++ b/filter.go
@@ -1,3 +1,5 @@
 package typhon
 
+// Filter functions compose with Services to modify their observed behaviour. They might change a service's input or
+// output, or elect not to call the underlying service at all.
 type Filter func(Request, Service) Response

--- a/http.go
+++ b/http.go
@@ -54,7 +54,7 @@ func HttpHandler(svc Service) http.Handler {
 			Request: *httpReq}
 		rsp := svc(req)
 
-		// Write the response out to the wire
+		// Write the response out
 		for k, v := range rsp.Header {
 			if k == "Content-Length" {
 				continue

--- a/service.go
+++ b/service.go
@@ -1,6 +1,6 @@
 package typhon
 
-// A Service is a function that takes a request, and produces a response. Services are used symetrically in
+// A Service is a function that takes a request and produces a response. Services are used symetrically in
 // both clients and servers.
 type Service func(req Request) Response
 


### PR DESCRIPTION
This contains various improvements to context handling, with the goal of eliminating context goroutine leaks. Specifically:

* Request cancellation behaviour can be controlled by using only context cancellation. To eliminate some complexity, remove the cancellation hooks from `ResponseFuture` (which are not used in Monzo's code anyway)
* The context library contains some performance optimisations when dealing with its own context types. For users of Typhon, it is common to use a Request as a context, preventing these performance optimisations from working properly. Internally, Typhon will now unwrap these contexts.
* If a context can never be cancelled, it returns a `nil` channel on `.Done()`. In this case, don't kick off a background goroutine that responds to cancellation in the client.