### PR TITLE
When copying bodies into a bufCloser, close the source Reader 🚪

### DIFF
--- a/response.go
+++ b/response.go
@@ -65,6 +65,8 @@ func (r *Response) Write(b []byte) (int, error) {
 				// This can be quite bad; we have consumed (and possibly lost) some of the original body
 				return 0, err
 			}
+			// rc will never again be accessible: once it's copied it must be closed
+			rc.Close()
 		}
 		r.Body = buf
 		return buf.Write(b)
@@ -80,10 +82,11 @@ func (r *Response) BodyBytes(consume bool) ([]byte, error) {
 	case *bufCloser:
 		return rc.Bytes(), nil
 	default:
-		rdr := io.Reader(rc)
 		buf := &bufCloser{}
 		r.Body = buf
-		rdr = io.TeeReader(rdr, buf)
+		rdr := io.TeeReader(rc, buf)
+		// rc will never again be accessible: once it's copied it must be closed
+		defer rc.Close()
 		return ioutil.ReadAll(rdr)
 	}
 }

--- a/terrors.go
+++ b/terrors.go
@@ -71,6 +71,9 @@ func ErrorFilter(req Request, svc Service) Response {
 	if rsp.Error != nil {
 		if rsp.StatusCode == http.StatusOK {
 			// We got an error, but there is no error in the underlying response; marshal
+			if rsp.Body != nil {
+				rsp.Body.Close()
+			}
 			rsp.Body = &bufCloser{}
 			terr := terrors.Wrap(rsp.Error, nil).(*terrors.Error)
 			rsp.Encode(terrors.Marshal(terr))


### PR DESCRIPTION
We think that these convenience copies _may_ be the source of some memory leaks. 🚰 