### PR TITLE
Close a response body on any read error, or when exhausted 🌪

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -58,10 +58,12 @@ func (w *countingWriter) Write(p []byte) (int, error) {
 type doneReader struct {
 	closed     chan struct{}
 	closedOnce sync.Once
+	length     int64 // length of the underlying reader in bytes, if known. -1 indicates unknown
+	read       int64 // number of bytes read
 	io.ReadCloser
 }
 
-func newDoneReader(r io.ReadCloser) *doneReader {
+func newDoneReader(r io.ReadCloser, length int64) *doneReader {
 	return &doneReader{
 		closed:     make(chan struct{}),
 		ReadCloser: r}
@@ -75,7 +77,10 @@ func (r *doneReader) Close() error {
 
 func (r *doneReader) Read(p []byte) (int, error) {
 	n, err := r.ReadCloser.Read(p)
-	if err == io.EOF {
+	r.read += int64(n)
+	// If we got an error reading, or the reader's length is known and is now exhausted, close
+	// the underlying reaer
+	if err != nil || (r.length >= 0 && r.read >= r.length) {
 		r.Close()
 	}
 	return n, err

--- a/buffer.go
+++ b/buffer.go
@@ -58,7 +58,7 @@ func (w *countingWriter) Write(p []byte) (int, error) {
 type doneReader struct {
 	closed     chan struct{}
 	closedOnce sync.Once
-	length     int64 // length of the underlying reader in bytes, if known. -1 indicates unknown
+	length     int64 // length of the underlying reader in bytes, if known. ≥0 indicates unknown
 	read       int64 // number of bytes read
 	io.ReadCloser
 }
@@ -80,7 +80,7 @@ func (r *doneReader) Read(p []byte) (int, error) {
 	r.read += int64(n)
 	// If we got an error reading, or the reader's length is known and is now exhausted, close
 	// the underlying reader
-	if err != nil || (r.length >= 0 && r.read >= r.length) {
+	if err != nil || (r.length > 0 && r.read >= r.length) {
 		r.Close()
 	}
 	return n, err

--- a/buffer.go
+++ b/buffer.go
@@ -79,7 +79,7 @@ func (r *doneReader) Read(p []byte) (int, error) {
 	n, err := r.ReadCloser.Read(p)
 	r.read += int64(n)
 	// If we got an error reading, or the reader's length is known and is now exhausted, close
-	// the underlying reaer
+	// the underlying reader
 	if err != nil || (r.length >= 0 && r.read >= r.length) {
 		r.Close()
 	}

--- a/client.go
+++ b/client.go
@@ -51,7 +51,7 @@ func HttpService(rt http.RoundTripper) Service {
 		// If the calling context is infinite (ie. returns nil for Done()), it can never signal cancellation
 		// so we bypass this as a performance optimisation
 		if httpRsp != nil && httpRsp.Body != nil && ctx.Done() != nil {
-			body := newDoneReader(httpRsp.Body)
+			body := newDoneReader(httpRsp.Body, httpRsp.ContentLength)
 			httpRsp.Body = body
 			go func() {
 				select {


### PR DESCRIPTION
After getting read error on a response body, it's very unlikely (perhaps impossible) that subsequent reads would be useful, and it's better to release its resources than perhaps hold onto them forever.

Also, this PR makes Typhon tolerant of reads of response bodies that are exactly their `ContentLength`.