### PR TITLE
Automatically close request/response bodies when they are decoded

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -66,6 +66,7 @@ type doneReader struct {
 func newDoneReader(r io.ReadCloser, length int64) *doneReader {
 	return &doneReader{
 		closed:     make(chan struct{}),
+		length:     length,
 		ReadCloser: r}
 }
 

--- a/buffer.go
+++ b/buffer.go
@@ -54,11 +54,12 @@ func (w *countingWriter) Write(p []byte) (int, error) {
 }
 
 // doneReader is a wrapper around a ReadCloser which provides notification when the stream has been fully consumed
-// (ie. when EOF is reached, or when the reader is closed.)
+// (ie. when EOF is reached, when the reader is explicitly closed, or if the size of the underlying reader is known,
+// when it has been fully read [even if EOF is not reached.])
 type doneReader struct {
 	closed     chan struct{}
 	closedOnce sync.Once
-	length     int64 // length of the underlying reader in bytes, if known. ≥0 indicates unknown
+	length     int64 // length of the underlying reader in bytes, if known. ≤0 indicates unknown
 	read       int64 // number of bytes read
 	io.ReadCloser
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -60,6 +60,10 @@ func (suite *e2eSuite) TestStraightforward() {
 	rsp := req.Send().Response()
 	suite.Require().NoError(rsp.Error)
 	suite.Assert().Equal(http.StatusOK, rsp.StatusCode)
+	body := map[string]string{}
+	suite.Assert().NoError(rsp.Decode(&body))
+	suite.Assert().Equal(map[string]string{
+		"b": "a"}, body)
 	// The response is simple too; shouldn't be chunked
 	suite.Assert().NotContains(rsp.TransferEncoding, "chunked")
 	suite.Assert().True(rsp.ContentLength > 0)

--- a/request.go
+++ b/request.go
@@ -50,8 +50,10 @@ func (r *Request) Encode(v interface{}) {
 
 // Decode de-serialises the JSON body into the passed object.
 func (r Request) Decode(v interface{}) error {
-	defer r.Body.Close()
-	err := json.NewDecoder(r.Body).Decode(v)
+	b, err := r.BodyBytes(true)
+	if err == nil {
+		err = json.Unmarshal(b, v)
+	}
 	return terrors.WrapWithCode(err, nil, terrors.ErrBadRequest)
 }
 
@@ -77,6 +79,7 @@ func (r *Request) Write(b []byte) (int, error) {
 
 func (r *Request) BodyBytes(consume bool) ([]byte, error) {
 	if consume {
+		defer r.Body.Close()
 		return ioutil.ReadAll(r.Body)
 	}
 

--- a/request.go
+++ b/request.go
@@ -50,6 +50,7 @@ func (r *Request) Encode(v interface{}) {
 
 // Decode de-serialises the JSON body into the passed object.
 func (r Request) Decode(v interface{}) error {
+	defer r.Body.Close()
 	err := json.NewDecoder(r.Body).Decode(v)
 	return terrors.WrapWithCode(err, nil, terrors.ErrBadRequest)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,26 @@
+package typhon
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRequestDecodeCloses verifies that a request body is closed after calling Decode()
+func TestRequestDecodeCloses(t *testing.T) {
+	t.Parallel()
+	req := NewRequest(nil, "GET", "/", nil)
+	b := []byte("{\"a\":\"b\"}\n")
+	r := newDoneReader(ioutil.NopCloser(bytes.NewReader(b)), -1)
+	req.Body = r
+
+	bout := map[string]string{}
+	req.Decode(&bout)
+	select {
+	case <-r.closed:
+	default:
+		assert.Fail(t, "response body was not closed after Decode()")
+	}
+}

--- a/response.go
+++ b/response.go
@@ -40,8 +40,11 @@ func (r *Response) Decode(v interface{}) error {
 	} else if r.Response == nil {
 		err = terrors.InternalService("", "Response has no body", nil)
 	} else {
-		defer r.Body.Close()
-		err = json.NewDecoder(r.Body).Decode(v)
+		var b []byte
+		b, err = r.BodyBytes(true)
+		if err == nil {
+			err = json.Unmarshal(b, v)
+		}
 		err = terrors.WrapWithCode(err, nil, terrors.ErrBadResponse)
 	}
 	if r.Error == nil {

--- a/response.go
+++ b/response.go
@@ -1,6 +1,7 @@
 package typhon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -100,14 +101,19 @@ func (r *Response) Writer() ResponseWriter {
 		r: r}
 }
 
-func (r *Response) String() string {
-	if r != nil {
-		if r.Response != nil {
-			return fmt.Sprintf("Response(%d, error: %v)", r.StatusCode, r.Error)
-		}
-		return fmt.Sprintf("Response(???, error: %v)", r.Error)
+func (r Response) String() string {
+	b := new(bytes.Buffer)
+	fmt.Fprint(b, "Response(")
+	if r.Response != nil {
+		fmt.Fprintf(b, "%d", r.StatusCode)
+	} else {
+		fmt.Fprint(b, "???")
 	}
-	return "Response(Unknown)"
+	if r.Error != nil {
+		fmt.Fprintf(b, ", error: %v", r.Error)
+	}
+	fmt.Fprint(b, ")")
+	return b.String()
 }
 
 func newHttpResponse(req Request) *http.Response {


### PR DESCRIPTION
`Request.Decode()` and `Response.Decode()` are convenience methods that we use extensively for unmarshalling HTTP bodies. These are not suitable as methods that can be called repeatedly to yield multiple values in a streaming fashion. These methods' implementations however, used `json.Decoder` internally, which _is_ meant for streaming use.

The problem with this is that `json.Decoder` may not read the entire stream: quite reasonably it reads only as much as it needs in order to yield a value, and presumes the stream is infinite. The way this was used inside `.Decode()` meant that a response body may never get closed. That's because it's common for a response body to be terminated with new line (`\n`) character, which the `Decoder` may leave unread. This would mean that the `doneReader` wouldn't see the body as being fully-read and leave it open.

This switches the implementations of `.Decode()` to use `json.Unmarshal`, which is not streaming. Instead of reading only chunks of the body, these methods now call `.BodyBytes()`, which explicitly closes the underlying reader.