### PR TITLE
Add 499 status code for request cancelation

### DIFF
--- a/terrors.go
+++ b/terrors.go
@@ -22,6 +22,11 @@ var (
 		terrors.ErrPreconditionFailed: http.StatusPreconditionFailed,
 		terrors.ErrTimeout:            http.StatusGatewayTimeout,
 		terrors.ErrUnauthorized:       http.StatusUnauthorized,
+
+		// If the client disconnects it won't receive this response status code
+		// However, this allows intermediate proxies to distinguish this behaviour
+		// giving similar behaviour to nginx
+		terrors.ErrContextCanceled: 499,
 	}
 	mapStatus2Terr map[int]string
 )


### PR DESCRIPTION
Similar to monzo/terrors#8 I'd like to be able to identify context/request cancelations, and return a specific status code for these. In the case of a client disconnection triggering the request cancelation the status code will not actually be returned to the client, but is still useful for intermediate proxies / services. 

I've copied nginx here, using the non-standard `499` status code to represent this.

Something which is a bit more interesting is this effectively identifies a context being canceled somewhere down the request chain bubbling up to the http server. There are arguably two subtly different cases which we should consider:

 - The parent request which this http server is processing has been canceled (parent context canceled). I think this should return a 499 or similar, allowing proxies to log or handle this.
 - A child request has been canceled due to a deadline being exceeded, but the parent context which this http server is processing is _not_ "Done". In this case the client is still connected, and returning a 499 status code to the client is not acceptable - this should perhaps default back to an internal service error of some form.

I _think_ we can distinguish between these two cases in the `ErrorFilter` by checking the status of the request context, but I'd love some thoughts on this before I tackle it. In the simple case, adding this error code will get us part of the way there, and fixes my immediate problem 😄 