### PR TITLE
Automatically buffered chunk response bodies which exceed 5MB

### DIFF
--- a/http.go
+++ b/http.go
@@ -8,6 +8,12 @@ import (
 	"github.com/monzo/slog"
 )
 
+const (
+	// chunkThreshold is a byte threshold above which request and response bodies that result from using buffered I/O
+	// within Typhon will be transferred with chunked encoding on the wire.
+	chunkThreshold = 5 * 1000000 // 5 megabytes
+)
+
 func isStreamingRsp(rsp Response) bool {
 	// Most straightforward: service may have set rsp.Body to a streamer
 	if s, ok := rsp.Body.(*streamer); ok && s != nil {
@@ -28,6 +34,7 @@ func isStreamingRsp(rsp Response) bool {
 	return false
 }
 
+// HttpHandler transforms the given Service into a http.Handler, suitable for use directly with net/http
 func HttpHandler(svc Service) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, httpReq *http.Request) {
 		ctx, cancel := context.WithCancel(httpReq.Context())

--- a/request.go
+++ b/request.go
@@ -43,7 +43,7 @@ func (r *Request) Encode(v interface{}) {
 		return
 	}
 	r.Header.Set("Content-Type", "application/json")
-	if r.ContentLength < 0 {
+	if r.ContentLength < 0 && cw.n < chunkThreshold {
 		r.ContentLength = int64(cw.n)
 	}
 }

--- a/response.go
+++ b/response.go
@@ -27,7 +27,7 @@ func (r *Response) Encode(v interface{}) {
 		return
 	}
 	r.Header.Set("Content-Type", "application/json")
-	if r.ContentLength < 0 {
+	if r.ContentLength < 0 && cw.n < chunkThreshold {
 		r.ContentLength = int64(cw.n)
 	}
 }


### PR DESCRIPTION
In #79 I explicitly disabled body chunking for all response bodies which are buffered before being sent. This improved performance and ensured intermediary proxies can retry small bodies, but it is not desirable when the body is actually quite large. In Monzo's case, if the body size exceeded the maximum we've configured in linkerd, it would fail outright.

This puts a 5MB cap in place, above which any buffered body will be chunked when it's sent.

Fixes PLAT-1321.