### PR TITLE
Improvements to Router 🔀

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestE2E(t *testing.T) {
-	t.Parallel()
 	suite.Run(t, &e2eSuite{})
 }
 

--- a/router.go
+++ b/router.go
@@ -8,57 +8,49 @@ import (
 	"github.com/monzo/terrors"
 )
 
-type Router interface {
-	// OPTIONS is a shortcut for Register("OPTIONS", path, svc).
-	OPTIONS(pattern string, svc Service)
-	// GET is a shortcut for Register("GET", path, svc).
-	GET(pattern string, svc Service)
-	// HEAD is a shortcut for Register("HEAD", path, svc).
-	HEAD(pattern string, svc Service)
-	// POST is a shortcut for Register("POST", path, svc).
-	POST(pattern string, svc Service)
-	// PUT is a shortcut for Register("PUT", path, svc).
-	PUT(pattern string, svc Service)
-	// DELETE is a shortcut for Register("DELETE", path, svc).
-	DELETE(pattern string, svc Service)
-	// TRACE is a shortcut for Register("TRACE", path, svc).
-	TRACE(pattern string, svc Service)
-	// Register associates a Service with a method and path.
-	Register(method, pattern string, svc Service)
-	// Lookup returns the Service, pattern, and extracted path parameters for the HTTP method and path.
-	Lookup(method, path string) (svc Service, pattern string, params map[string]string, ok bool)
-	// Serve returns a Service which will route inbound requests to the enclosed routes.
-	Serve() Service
-	// Pattern returns the registered pattern which matches the given request.
-	Pattern(req Request) string
-	// Params returns extracted URL parameters, assuming the request has been routed and has captured parameters.
-	Params(req Request) map[string]string
-}
-
-type router struct {
+// A Router multiplexes requests to a set of Services by pattern matching on method and path, and can also extract
+// parameters from paths.
+type Router struct {
 	e    *echo.Echo
 	r    *echo.Router
 	svcs map[string]Service
-	m    sync.RWMutex
+	m    *sync.RWMutex
 }
 
 // NewRouter vends a new implementation of Router
 func NewRouter() Router {
 	e := echo.New()
-	return &router{
+	return Router{
 		e:    e,
 		r:    echo.NewRouter(e),
-		svcs: make(map[string]Service, 10)}
+		svcs: make(map[string]Service, 10),
+		m:    new(sync.RWMutex)}
 }
 
-func (r *router) Register(method, pattern string, svc Service) {
+// Register associates a Service with a method and path.
+//
+// Method is a single HTTP method name, or * which is expanded to {OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE}.
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) Register(method, pattern string, svc Service) {
+	echoHandler := func(c echo.Context) error { return nil }
+
 	r.m.Lock()
 	defer r.m.Unlock()
-	r.r.Add(method, pattern, func(c echo.Context) error { return nil })
-	r.svcs[method+pattern] = svc
+
+	if method == "*" {
+		// Expand * to the set of all known methods
+		for _, m := range [...]string{"GET", "CONNECT", "DELETE", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"} {
+			r.r.Add(m, pattern, echoHandler)
+			r.svcs[m+pattern] = svc
+		}
+	} else {
+		r.r.Add(method, pattern, echoHandler)
+		r.svcs[method+pattern] = svc
+	}
 }
 
-func (r *router) Lookup(method, path string) (Service, string, map[string]string, bool) {
+// Lookup returns the Service, pattern, and extracted path parameters for the HTTP method and path.
+func (r *Router) Lookup(method, path string) (Service, string, map[string]string, bool) {
 	c := r.e.AcquireContext()
 	defer r.e.ReleaseContext(c)
 	c.Reset(nil, nil)
@@ -86,7 +78,8 @@ func (r *router) Lookup(method, path string) (Service, string, map[string]string
 	return svc, pattern, params, true
 }
 
-func (r *router) Serve() Service {
+// Serve returns a Service which will route inbound requests to the enclosed routes.
+func (r *Router) Serve() Service {
 	return func(req Request) Response {
 		svc, _, _, ok := r.Lookup(req.Method, req.URL.Path)
 		if !ok {
@@ -99,21 +92,61 @@ func (r *router) Serve() Service {
 	}
 }
 
-func (r *router) Pattern(req Request) string {
+// Pattern returns the registered pattern which matches the given request.
+func (r *Router) Pattern(req Request) string {
 	_, pattern, _, _ := r.Lookup(req.Method, req.URL.Path)
 	return pattern
 }
 
-func (r *router) Params(req Request) map[string]string {
+// Params returns extracted path parameters, assuming the request has been routed and has captured parameters.
+func (r *Router) Params(req Request) map[string]string {
 	_, _, params, _ := r.Lookup(req.Method, req.URL.Path)
 	return params
 }
 
 // Sugar
-func (r *router) OPTIONS(pattern string, svc Service) { r.Register("OPTIONS", pattern, svc) }
-func (r *router) GET(pattern string, svc Service)     { r.Register("GET", pattern, svc) }
-func (r *router) HEAD(pattern string, svc Service)    { r.Register("HEAD", pattern, svc) }
-func (r *router) POST(pattern string, svc Service)    { r.Register("POST", pattern, svc) }
-func (r *router) PUT(pattern string, svc Service)     { r.Register("PUT", pattern, svc) }
-func (r *router) DELETE(pattern string, svc Service)  { r.Register("DELETE", pattern, svc) }
-func (r *router) TRACE(pattern string, svc Service)   { r.Register("TRACE", pattern, svc) }
+
+// GET is shorthand for Register("GET", pattern, svc).
+//
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) GET(pattern string, svc Service) { r.Register("GET", pattern, svc) }
+
+// CONNECT is shorthand for Register("CONNECT", pattern, svc).
+//
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) CONNECT(pattern string, svc Service) { r.Register("CONNECT", pattern, svc) }
+
+// DELETE is shorthand for Register("DELETE", pattern, svc).
+//
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) DELETE(pattern string, svc Service) { r.Register("DELETE", pattern, svc) }
+
+// HEAD is shorthand for Register("HEAD", pattern, svc).
+//
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) HEAD(pattern string, svc Service) { r.Register("HEAD", pattern, svc) }
+
+// OPTIONS is shorthand for Register("OPTIONS", pattern, svc).
+//
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) OPTIONS(pattern string, svc Service) { r.Register("OPTIONS", pattern, svc) }
+
+// PATCH is shorthand for Register("PATCH", pattern, svc).
+//
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) PATCH(pattern string, svc Service) { r.Register("PATCH", pattern, svc) }
+
+// POST is shorthand for Register("POST", pattern, svc).
+//
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) POST(pattern string, svc Service) { r.Register("POST", pattern, svc) }
+
+// PUT is shorthand for Register("PUT", pattern, svc).
+//
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) PUT(pattern string, svc Service) { r.Register("PUT", pattern, svc) }
+
+// TRACE is shorthand for Register("TRACE", pattern, svc).
+//
+// Pattern syntax is as described in echo's documentation: https://echo.labstack.com/guide/routing
+func (r *Router) TRACE(pattern string, svc Service) { r.Register("TRACE", pattern, svc) }

--- a/router_test.go
+++ b/router_test.go
@@ -31,7 +31,7 @@ func routerTestHarness() (Router, []routerTestCase) {
 	}
 	router.GET("/foo", svc)
 	router.GET("/foo/:param/baz", svc)
-	router.GET("/residual/*residuals", svc)
+	router.GET("/residual/*", svc)
 	router.Register("*", "/poly", svc)
 
 	cases := []routerTestCase{
@@ -69,7 +69,7 @@ func routerTestHarness() (Router, []routerTestCase) {
 			method:  http.MethodGet,
 			path:    "/residual/r",
 			status:  http.StatusOK,
-			pattern: "/residual/*residuals",
+			pattern: "/residual/*",
 			params: map[string]string{
 				"*": "r"},
 		},
@@ -78,7 +78,7 @@ func routerTestHarness() (Router, []routerTestCase) {
 			method:  http.MethodGet,
 			path:    "/residual/r/e/s/i/d/u/a/l",
 			status:  http.StatusOK,
-			pattern: "/residual/*residuals",
+			pattern: "/residual/*",
 			params: map[string]string{
 				"*": "r/e/s/i/d/u/a/l"},
 		},
@@ -87,7 +87,7 @@ func routerTestHarness() (Router, []routerTestCase) {
 			method:  http.MethodGet,
 			path:    "/residual/r/e/s/i/d/u/a/l/",
 			status:  http.StatusOK,
-			pattern: "/residual/*residuals",
+			pattern: "/residual/*",
 			params: map[string]string{
 				"*": "r/e/s/i/d/u/a/l/"},
 		},

--- a/router_test.go
+++ b/router_test.go
@@ -25,10 +25,8 @@ type routerTestCase struct {
 
 func routerTestHarness() (Router, []routerTestCase) {
 	router := NewRouter()
+	rsp := NewResponse(Request{})
 	svc := func(req Request) Response {
-		rsp := NewResponse(req)
-		rsp.Header.Set("Router-Pattern", router.Pattern(req))
-		rsp.Encode(router.Params(req))
 		return rsp
 	}
 	router.GET("/foo", svc)
@@ -129,10 +127,10 @@ func TestRouter(t *testing.T) {
 			assert.Equal(t, rsp.StatusCode, c.status)
 			if rsp.StatusCode == http.StatusOK {
 				require.NoError(t, rsp.Error)
-				assert.Equal(t, c.pattern, rsp.Header.Get("Router-Pattern"))
 
-				params := map[string]string{}
-				require.NoError(t, rsp.Decode(&params))
+				_, pattern, params, ok := router.Lookup(c.method, c.path)
+				require.True(t, ok)
+				assert.Equal(t, c.pattern, pattern)
 				assert.Equal(t, c.params, params)
 			}
 		})


### PR DESCRIPTION
`Router` is a fairly crucial piece of functionality in Typhon, used internally at Monzo in basically every backend service – often multiple times. However it's also poorly tested and has subtle behaviour that can be hard to understand.

## `Router` is no longer an interface

This change simplifies `Router` somewhat so it's no longer an interface. The rest of Typhon doesn't really care about `Router`s – it only sees the `Service`s that are materialised from them – so it didn't make sense to have an interface adding a layer of indirection. Calling code should not need to be modified so this is not a breaking change.

## Catch-all method sugar

`"*"` can now be passed as a method name to `Register` if a caller wants all methods for a given path to be routed to a single service. Under the hood, `*` is expanded to a set of {`OPTIONS`, `GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `TRACE`}.

## Housekeeping

`Router`'s methods are better-documented, there are more test cases, and now benchmarks too.

## Performance

A number of small improvements mean that routing requests now often involves zero memory allocations, and is substantially faster:

```
benchmark                                                  old allocs     new allocs     delta
BenchmarkRouter/Serve/GET/-4                               20             20             +0.00%
BenchmarkRouter/Serve/GET/foo-4                            1              0              -100.00%
BenchmarkRouter/Serve/GET/foo/bar2bär/baz-4                2              0              -100.00%
BenchmarkRouter/Serve/GET/foo/bar/bar/baz-4                20             20             +0.00%
BenchmarkRouter/Serve/GET/residual/r-4                     2              0              -100.00%
BenchmarkRouter/Serve/GET/residual/r/e/s/i/d/u/a/l-4       2              0              -100.00%
BenchmarkRouter/Serve/GET/residual/r/e/s/i/d/u/a/l/-4      2              0              -100.00%
BenchmarkRouter/Serve/WTAF/poly-4                          20             20             +0.00%
BenchmarkRouter/Serve/GET/poly-4                           20             0              -100.00%
BenchmarkRouter/Serve/CONNECT/poly-4                       20             0              -100.00%
BenchmarkRouter/Serve/DELETE/poly-4                        20             0              -100.00%
BenchmarkRouter/Serve/HEAD/poly-4                          20             0              -100.00%
BenchmarkRouter/Serve/OPTIONS/poly-4                       20             0              -100.00%
BenchmarkRouter/Serve/PATCH/poly-4                         20             0              -100.00%
BenchmarkRouter/Serve/POST/poly-4                          20             0              -100.00%
BenchmarkRouter/Serve/PUT/poly-4                           20             0              -100.00%
BenchmarkRouter/Serve/TRACE/poly-4                         20             0              -100.00%
```

```
benchmark                                                  old ns/op     new ns/op     delta
BenchmarkRouter/Serve/GET/-4                               4277          4156          -2.83%
BenchmarkRouter/Serve/GET/foo-4                            302           216           -28.48%
BenchmarkRouter/Serve/GET/foo/bar2bär/baz-4                785           273           -65.22%
BenchmarkRouter/Serve/GET/foo/bar/bar/baz-4                14729         4602          -68.76%
BenchmarkRouter/Serve/GET/residual/r-4                     684           243           -64.47%
BenchmarkRouter/Serve/GET/residual/r/e/s/i/d/u/a/l-4       513           250           -51.27%
BenchmarkRouter/Serve/GET/residual/r/e/s/i/d/u/a/l/-4      565           241           -57.35%
BenchmarkRouter/Serve/WTAF/poly-4                          4821          4869          +1.00%
BenchmarkRouter/Serve/GET/poly-4                           4215          225           -94.66%
BenchmarkRouter/Serve/CONNECT/poly-4                       5496          193           -96.49%
BenchmarkRouter/Serve/DELETE/poly-4                        4363          223           -94.89%
BenchmarkRouter/Serve/HEAD/poly-4                          4525          308           -93.19%
BenchmarkRouter/Serve/OPTIONS/poly-4                       5198          209           -95.98%
BenchmarkRouter/Serve/PATCH/poly-4                         5039          230           -95.44%
BenchmarkRouter/Serve/POST/poly-4                          4490          266           -94.08%
BenchmarkRouter/Serve/PUT/poly-4                           4262          226           -94.70%
BenchmarkRouter/Serve/TRACE/poly-4                         4185          230           -94.50%
```