### PR TITLE
Make it possible to get the Request for a Response 👯‍♀️

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -60,6 +60,8 @@ func (suite *e2eSuite) TestStraightforward() {
 	rsp := req.Send().Response()
 	suite.Require().NoError(rsp.Error)
 	suite.Assert().Equal(http.StatusOK, rsp.StatusCode)
+	suite.Require().NotNil(rsp.Request)
+	suite.Assert().Equal(req, *rsp.Request)
 	body := map[string]string{}
 	suite.Assert().NoError(rsp.Decode(&body))
 	suite.Assert().Equal(map[string]string{
@@ -325,7 +327,7 @@ func (suite *e2eSuite) TestResponseAutoChunking() {
 	defer leaktest.Check(suite.T())()
 	var sendRsp Response
 	svc := Service(func(req Request) Response {
-		sendRsp.ctx = req
+		sendRsp.Request = &req
 		return sendRsp
 	})
 	svc = svc.Filter(ErrorFilter)

--- a/response.go
+++ b/response.go
@@ -2,7 +2,6 @@ package typhon
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,8 +14,8 @@ import (
 // A Response is Typhon's wrapper around http.Response, used by both clients and servers.
 type Response struct {
 	*http.Response
-	Error error
-	ctx   context.Context
+	Error   error
+	Request *Request // The Request that we are responding to
 }
 
 // Encode serialises the passed object as JSON into the body (and sets appropriate headers).
@@ -56,7 +55,7 @@ func (r *Response) Decode(v interface{}) error {
 
 func (r *Response) Write(b []byte) (int, error) {
 	if r.Response == nil {
-		r.Response = newHttpResponse(Request{})
+		r.Response = newHTTPResponse(Request{})
 	}
 	switch rc := r.Body.(type) {
 	// In the "regular" case, the response body will be a bufCloser; we can write
@@ -122,7 +121,7 @@ func (r Response) String() string {
 	return b.String()
 }
 
-func newHttpResponse(req Request) *http.Response {
+func newHTTPResponse(req Request) *http.Response {
 	return &http.Response{
 		StatusCode:    http.StatusOK, // Seems like a reasonable default
 		Proto:         req.Proto,
@@ -136,7 +135,7 @@ func newHttpResponse(req Request) *http.Response {
 // NewResponse constructs a Response
 func NewResponse(req Request) Response {
 	return Response{
-		ctx:      req.Context,
+		Request:  &req,
 		Error:    nil,
-		Response: newHttpResponse(req)}
+		Response: newHTTPResponse(req)}
 }

--- a/terrors.go
+++ b/terrors.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/monzo/slog"
+	"github.com/monzo/slog"
 	"github.com/monzo/terrors"
 	"github.com/monzo/terrors/proto"
 )
@@ -62,10 +62,10 @@ func ErrorFilter(req Request, svc Service) Response {
 	}
 
 	if rsp.Response == nil {
-		rsp.Response = newHttpResponse(req)
+		rsp.Response = newHTTPResponse(req)
 	}
-	if rsp.ctx == nil {
-		rsp.ctx = req
+	if rsp.Request == nil {
+		rsp.Request = &req
 	}
 
 	if rsp.Error != nil {
@@ -87,11 +87,12 @@ func ErrorFilter(req Request, svc Service) Response {
 		case "1":
 			tp := &terrorsproto.Error{}
 			if err := json.Unmarshal(b, tp); err != nil {
-				log.Warn(rsp.ctx, "Failed to unmarshal terror: %v", err)
+				slog.Warn(rsp.Request, "Failed to unmarshal terror: %v", err)
 				rsp.Error = errors.New(string(b))
 			} else {
 				rsp.Error = terrors.Unmarshal(tp)
 			}
+
 		default:
 			rsp.Error = errors.New(string(b))
 		}


### PR DESCRIPTION
`Response` already inherited a `Request` field from `http.Response`, but it wasn't used and had the wrong (non-Typhon) type. The `Response` type also already contained a `ctx` field with the request's context.

There's now a `Request` field containing the Typhon Request `that` is being responded to, which is more useful.