### PR TITLE
Improved error handling for client disconnections ☎️

### DIFF
--- a/http_darwin.go
+++ b/http_darwin.go
@@ -1,0 +1,16 @@
+package typhon
+
+import (
+	"syscall"
+
+	"github.com/monzo/slog"
+)
+
+func copyErrnoSeverity(err syscall.Errno) slog.Severity {
+	switch err {
+	case syscall.EPIPE: // the client has cancelled the request
+		return slog.DebugSeverity
+	default:
+		return slog.WarnSeverity
+	}
+}

--- a/http_linux.go
+++ b/http_linux.go
@@ -1,0 +1,16 @@
+package typhon
+
+import (
+	"syscall"
+
+	"github.com/monzo/slog"
+)
+
+func copyErrnoSeverity(err syscall.Errno) slog.Severity {
+	switch err {
+	case syscall.EPIPE: // the client has cancelled the request
+		return slog.DebugSeverity
+	default:
+		return slog.WarnSeverity
+	}
+}

--- a/http_other.go
+++ b/http_other.go
@@ -1,0 +1,13 @@
+// +build !linux,!darwin
+
+package typhon
+
+import (
+	"syscall"
+
+	"github.com/monzo/slog"
+)
+
+func copyErrnoSeverity(err syscall.Errno) slog.Severity {
+	return slog.WarnSeverity
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,19 @@
+package typhon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	Client = Service(BareClient).Filter(ErrorFilter)
+	os.Exit(m.Run())
+}
+
+func serve(t *testing.T, svc Service) Server {
+	s, err := Listen(svc, "localhost:0")
+	require.NoError(t, err)
+	return s
+}


### PR DESCRIPTION
When a client disconnects, Typhon currently slogs an error like this:

```
1537553768766857000 [Error] Error copying response body: write tcp 127.0.0.1:54775->127.0.0.1:54778: write: broken pipe
```

This isn't fantastically helpful and unless you're familiar with the guts of Linux, you would be forgiven for not grokking that "broken pipe" in this circumstance is a perfectly normal thing to happen, and isn't indicative of a server malfunction.

Typhon now downgrades this type of "error" to a debug event, which is really all this situation should be to an operator.

Other changes include a new test to make sure that `Streamer.Write` doesn't block forever when a client disconnects, and a refactor of the e2e tests to move them to a "vanilla" test style instead of using a cumbersome test suite.