### PR TITLE
Fix golint path for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin
-  - go get -v github.com/golang/lint/golint
+  - go get -v golang.org/x/lint/golint
 
 before_script:
   - go vet ./...


### PR DESCRIPTION
Travis build was failing because golint's canonical import path has been moved.