### PR TITLE
Expose error in typhon.Request 🙈

### DIFF
--- a/request.go
+++ b/request.go
@@ -15,7 +15,7 @@ import (
 type Request struct {
 	http.Request
 	context.Context
-	err error // Any error from request construction; read by Client
+	Error error // Any error from request construction
 }
 
 // unwrappedContext returns the most "unwrapped" Context possible for that in the request.
@@ -39,7 +39,7 @@ func (r *Request) Encode(v interface{}) {
 	cw := &countingWriter{
 		Writer: r}
 	if err := json.NewEncoder(cw).Encode(v); err != nil {
-		r.err = terrors.Wrap(err, nil)
+		r.Error = terrors.Wrap(err, nil)
 		return
 	}
 	r.Header.Set("Content-Type", "application/json")
@@ -130,7 +130,7 @@ func NewRequest(ctx context.Context, method, url string, body interface{}) Reque
 	httpReq, err := http.NewRequest(method, url, nil)
 	req := Request{
 		Context: ctx,
-		err:     err}
+		Error:   err}
 	if httpReq != nil {
 		httpReq.ContentLength = -1
 		httpReq.Body = &bufCloser{}

--- a/terrors.go
+++ b/terrors.go
@@ -54,9 +54,9 @@ func status2TerrCode(code int) string {
 func ErrorFilter(req Request, svc Service) Response {
 	// If the request contains an error, short-circuit and return that directly
 	var rsp Response
-	if req.err != nil {
+	if req.Error != nil {
 		rsp = NewResponse(req)
-		rsp.Error = req.err
+		rsp.Error = req.Error
 	} else {
 		rsp = svc(req)
 	}


### PR DESCRIPTION
Those using `typhon.NewRequest` directly have no way of reading any underlying errors generated at request creation time since no error is returned explicitly.

This PR changes `typhon.Request` to make the `err` public as `Error`