### PR TITLE
Add simple service example

### DIFF
--- a/examples/stringsvc/cmd/client/main.go
+++ b/examples/stringsvc/cmd/client/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"github.com/monzo/typhon"
+	"github.com/monzo/typhon/examples/stringsvc/pkg/stringsvc"
+	"log"
+)
+
+func main() {
+	client := stringsvc.NewClient("http://localhost:8085", typhon.Client.Filter(typhon.ErrorFilter).Filter(typhon.H2cFilter))
+
+	resp, err := client.Uppercase("Hello world")
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("Got uppercase response: %s", resp)
+
+	count, err := client.Count(resp)
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("Got count response: %d", count)
+}

--- a/examples/stringsvc/cmd/server/main.go
+++ b/examples/stringsvc/cmd/server/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"github.com/monzo/typhon"
+	"github.com/monzo/typhon/examples/stringsvc/internal/app/stringsvc/service"
+	"github.com/monzo/typhon/examples/stringsvc/internal/app/stringsvc/transport"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	svc := service.New()
+	typhonHandler := transport.NewHTTPTransport(svc).Filter(typhon.ErrorFilter).Filter(typhon.H2cFilter)
+
+	srv, err := typhon.Listen(typhonHandler, ":8085")
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("Listening on %v", srv.Listener().Addr())
+
+	done := make(chan os.Signal)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+	<-done
+
+	log.Printf("Shutting down")
+	c, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	srv.Stop(c)
+}

--- a/examples/stringsvc/internal/app/stringsvc/service/service.go
+++ b/examples/stringsvc/internal/app/stringsvc/service/service.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"errors"
+	"github.com/monzo/typhon/examples/stringsvc/pkg/stringsvc"
+	"strings"
+)
+
+type service struct{}
+
+var ErrEmpty = errors.New("empty string")
+
+func New() stringsvc.Service {
+	return service{}
+}
+
+func (service) Uppercase(str string) (string, error) {
+	if str == "" {
+		return "", ErrEmpty
+	}
+
+	return strings.ToUpper(str), nil
+}
+
+func (service) Count(str string) (int, error) {
+	return len(str), nil
+}

--- a/examples/stringsvc/internal/app/stringsvc/transport/transport.go
+++ b/examples/stringsvc/internal/app/stringsvc/transport/transport.go
@@ -1,0 +1,58 @@
+package transport
+
+import (
+	"github.com/monzo/terrors"
+	"github.com/monzo/typhon"
+	"github.com/monzo/typhon/examples/stringsvc/internal/app/stringsvc/service"
+	"github.com/monzo/typhon/examples/stringsvc/pkg/stringsvc"
+	"github.com/monzo/typhon/examples/stringsvc/pkg/stringsvc/transport"
+)
+
+func handleUppercase(svc stringsvc.Service) typhon.Service {
+	return func(req typhon.Request) typhon.Response {
+		request := transport.UppercaseRequest{}
+		if err := req.Decode(&request); err != nil {
+			resp := req.Response(nil)
+			resp.Error = err
+			return resp
+		}
+
+		result, err := svc.Uppercase(request.S)
+		if err != nil {
+			resp := req.Response(nil)
+			switch err {
+			case service.ErrEmpty:
+				resp.Error = terrors.BadRequest("empty_string", err.Error(), nil)
+			default:
+				resp.Error = terrors.InternalService("", err.Error(), nil)
+			}
+			return resp
+		}
+
+		return req.Response(transport.UppercaseResponse{Value: result})
+	}
+}
+
+func handleCount(svc stringsvc.Service) typhon.Service {
+	return func(req typhon.Request) typhon.Response {
+		request := transport.CountRequest{}
+		if err := req.Decode(&request); err != nil {
+			resp := req.Response(nil)
+			resp.Error = err
+			return resp
+		}
+
+		result, _ := svc.Count(request.S)
+
+		return req.Response(transport.CountResponse{Value: result})
+	}
+}
+
+func NewHTTPTransport(service stringsvc.Service) typhon.Service {
+	router := typhon.Router{}
+
+	router.POST("/uppercase", handleUppercase(service))
+	router.POST("/count", handleCount(service))
+
+	return router.Serve()
+}

--- a/examples/stringsvc/pkg/stringsvc/client.go
+++ b/examples/stringsvc/pkg/stringsvc/client.go
@@ -1,0 +1,43 @@
+package stringsvc
+
+import (
+	"context"
+	"github.com/monzo/typhon"
+	"github.com/monzo/typhon/examples/stringsvc/pkg/stringsvc/transport"
+)
+
+type client struct {
+	baseUrl      string
+	typhonClient typhon.Service
+}
+
+func NewClient(baseUrl string, typhonClient typhon.Service) Service {
+	return &client{
+		baseUrl:      baseUrl,
+		typhonClient: typhonClient,
+	}
+}
+
+func (c client) Uppercase(s string) (string, error) {
+	req := typhon.NewRequest(context.Background(), "POST", c.baseUrl+"/uppercase", transport.UppercaseRequest{S: s})
+	response := req.SendVia(c.typhonClient).Response()
+
+	resp := transport.UppercaseResponse{}
+	if err := response.Decode(&resp); err != nil {
+		return "", err
+	}
+
+	return resp.Value, nil
+}
+
+func (c client) Count(s string) (int, error) {
+	req := typhon.NewRequest(context.Background(), "POST", c.baseUrl+"/count", transport.CountRequest{S: s})
+	response := req.SendVia(c.typhonClient).Response()
+
+	resp := transport.CountResponse{}
+	if err := response.Decode(&resp); err != nil {
+		return 0, err
+	}
+
+	return resp.Value, nil
+}

--- a/examples/stringsvc/pkg/stringsvc/service.go
+++ b/examples/stringsvc/pkg/stringsvc/service.go
@@ -1,0 +1,6 @@
+package stringsvc
+
+type Service interface {
+	Uppercase(s string) (string, error)
+	Count(s string) (int, error)
+}

--- a/examples/stringsvc/pkg/stringsvc/transport/transport.go
+++ b/examples/stringsvc/pkg/stringsvc/transport/transport.go
@@ -1,0 +1,17 @@
+package transport
+
+type UppercaseRequest struct {
+	S string `json:"s"`
+}
+
+type CountRequest struct {
+	S string `json:"s"`
+}
+
+type UppercaseResponse struct {
+	Value string `json:"value"`
+}
+
+type CountResponse struct {
+	Value int `json:"value"`
+}


### PR DESCRIPTION
This change adds an example based on go-kit's stringsvc1 example. I don't know how your services are organized, so I used a generic project format. The business logic is separated from the transport layer, and there is a client for calling the service.

I hope this might be useful for someone.

Thanks,
Josh