### PR TITLE
Typhon: Set response Request when routing

### DIFF
--- a/router.go
+++ b/router.go
@@ -120,7 +120,11 @@ func (r Router) Serve() Service {
 			return rsp
 		}
 		req.Context = context.WithValue(req.Context, routerContextKey, &r)
-		return svc(req)
+		rsp := svc(req)
+		if rsp.Request == nil {
+			rsp.Request = &req
+		}
+		return rsp
 	}
 }
 

--- a/router_test.go
+++ b/router_test.go
@@ -109,3 +109,20 @@ func TestRouterForRequest(t *testing.T) {
 	require.NotNil(t, reqRouter)
 	assert.Equal(t, router, *reqRouter)
 }
+
+func TestRouterSetsRequest(t *testing.T) {
+	t.Parallel()
+
+	router := Router{}
+	router.GET("/", func(req Request) Response {
+		return Response{}
+	})
+
+	ctx := context.Background()
+	req := NewRequest(ctx, "GET", "/", map[string]string{"r": "foo"})
+	rsp := router.Serve()(req)
+	require.NotNil(t, rsp.Request)
+	// Request should be equal, bar the Context, which will have added value for routerContextKey
+	req.Context = rsp.Request.Context
+	assert.Equal(t, req, *rsp.Request)
+}


### PR DESCRIPTION
Common pattern of returning `typhon.Response{Error: ...}` on error means
that error responses can not be correlated back to the requests.

When routing requests to a Service, set the Request on the response if
is hasn't already been set.