### PR TITLE
Set content length in the request/response Write method

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -50,19 +50,6 @@ func (s *streamer) Close() error {
 	return s.pipeW.Close()
 }
 
-// countingWriter is a writer which proxies writes to an underlying io.Writer, keeping track of how many bytes have
-// been written in total
-type countingWriter struct {
-	n int
-	io.Writer
-}
-
-func (w *countingWriter) Write(p []byte) (int, error) {
-	n, err := w.Writer.Write(p)
-	w.n += n
-	return n, err
-}
-
 // doneReader is a wrapper around a ReadCloser which provides notification when the stream has been fully consumed
 // (ie. when EOF is reached, when the reader is explicitly closed, or if the size of the underlying reader is known,
 // when it has been fully read [even if EOF is not reached.])

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -128,7 +128,7 @@ func TestE2E(t *testing.T) {
 			"b": "a"}, body)
 		// The response is simple too; shouldn't be chunked
 		assert.NotContains(t, rsp.TransferEncoding, "chunked")
-		assert.Equal(t, int64(10), rsp.ContentLength)
+		assert.EqualValues(t, 10, rsp.ContentLength)
 	})
 }
 
@@ -328,7 +328,7 @@ func TestE2ENoFollowRedirect(t *testing.T) {
 		rsp := req.Send().Response()
 		assert.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusFound, rsp.StatusCode)
-		assert.Equal(t, int64(56), rsp.ContentLength)
+		assert.EqualValues(t, 56, rsp.ContentLength)
 	})
 }
 
@@ -369,7 +369,7 @@ func TestE2EProxiedStreamer(t *testing.T) {
 		if !rsp.ProtoAtLeast(2, 0) {
 			assert.Contains(t, rsp.TransferEncoding, "chunked")
 		}
-		assert.True(t, rsp.ContentLength < 0)
+		assert.EqualValues(t,-1, rsp.ContentLength)
 		for i := 0; i < 100; i++ {
 			chunks <- true
 			b := make([]byte, 500)
@@ -458,7 +458,7 @@ func TestE2ERequestAutoChunking(t *testing.T) {
 		rsp = req.Send().Response()
 		require.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusOK, rsp.StatusCode)
-		assert.Equal(t, rsp.ContentLength, int64(5))
+		assert.EqualValues(t, 5, rsp.ContentLength)
 		assert.False(t, receivedChunked)
 
 		// Large request using Encode(); should be chunked
@@ -502,7 +502,7 @@ func TestE2EResponseAutoChunking(t *testing.T) {
 		require.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusOK, rsp.StatusCode)
 		assert.Contains(t, rsp.TransferEncoding, "chunked")
-		assert.True(t, rsp.ContentLength < 0)
+		assert.EqualValues(t, -1, rsp.ContentLength)
 
 		// Small request using Encode(): should not be chunked
 		sendRsp = NewResponse(req)
@@ -511,7 +511,7 @@ func TestE2EResponseAutoChunking(t *testing.T) {
 		rsp = req.Send().Response()
 		require.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusOK, rsp.StatusCode)
-		assert.Equal(t, int64(10), rsp.ContentLength)
+		assert.EqualValues(t, 10, rsp.ContentLength)
 		assert.NotContains(t, rsp.TransferEncoding, "chunked")
 
 		// Large request using Encode(); should be chunked
@@ -525,7 +525,7 @@ func TestE2EResponseAutoChunking(t *testing.T) {
 		rsp = req.Send().Response()
 		require.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusOK, rsp.StatusCode)
-		assert.Equal(t, rsp.ContentLength, int64(-1))
+		assert.EqualValues(t, -1, rsp.ContentLength)
 		assert.Contains(t, rsp.TransferEncoding, "chunked")
 	})
 }
@@ -588,7 +588,7 @@ func TestE2EFullDuplex(t *testing.T) {
 		req.Body = Streamer()
 		defer req.Body.Close()
 		rsp := req.Send().Response()
-		assert.True(t, rsp.ContentLength < 0)
+		assert.EqualValues(t, -1, rsp.ContentLength)
 
 		for i := 0; i < 50; i++ {
 			b := []byte(fmt.Sprintf("foo %d", i))
@@ -604,7 +604,7 @@ func TestE2EFullDuplex(t *testing.T) {
 		}
 		close(chunks)
 
-		assert.True(t, rsp.ContentLength < 0)
+		assert.EqualValues(t, -1, rsp.ContentLength)
 	})
 }
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -458,6 +458,7 @@ func TestE2ERequestAutoChunking(t *testing.T) {
 		rsp = req.Send().Response()
 		require.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusOK, rsp.StatusCode)
+		assert.Equal(t, rsp.ContentLength, int64(5))
 		assert.False(t, receivedChunked)
 
 		// Large request using Encode(); should be chunked
@@ -510,6 +511,7 @@ func TestE2EResponseAutoChunking(t *testing.T) {
 		rsp = req.Send().Response()
 		require.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusOK, rsp.StatusCode)
+		assert.Equal(t, int64(10), rsp.ContentLength)
 		assert.NotContains(t, rsp.TransferEncoding, "chunked")
 
 		// Large request using Encode(); should be chunked
@@ -523,6 +525,7 @@ func TestE2EResponseAutoChunking(t *testing.T) {
 		rsp = req.Send().Response()
 		require.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusOK, rsp.StatusCode)
+		assert.Equal(t, rsp.ContentLength, int64(-1))
 		assert.Contains(t, rsp.TransferEncoding, "chunked")
 	})
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -128,7 +128,7 @@ func TestE2E(t *testing.T) {
 			"b": "a"}, body)
 		// The response is simple too; shouldn't be chunked
 		assert.NotContains(t, rsp.TransferEncoding, "chunked")
-		assert.True(t, rsp.ContentLength > 0)
+		assert.Equal(t, int64(10), rsp.ContentLength)
 	})
 }
 
@@ -264,6 +264,7 @@ func TestE2EError(t *testing.T) {
 		req := NewRequest(ctx, "GET", flav.URL(s), nil)
 		rsp := req.Send().Response()
 		assert.Equal(t, http.StatusUnauthorized, rsp.StatusCode)
+		assert.True(t, rsp.ContentLength > 0)
 
 		b, _ := rsp.BodyBytes(false)
 		assert.NotContains(t, string(b), "throwaway")
@@ -327,6 +328,7 @@ func TestE2ENoFollowRedirect(t *testing.T) {
 		rsp := req.Send().Response()
 		assert.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusFound, rsp.StatusCode)
+		assert.Equal(t, int64(56), rsp.ContentLength)
 	})
 }
 
@@ -499,6 +501,7 @@ func TestE2EResponseAutoChunking(t *testing.T) {
 		require.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusOK, rsp.StatusCode)
 		assert.Contains(t, rsp.TransferEncoding, "chunked")
+		assert.True(t, rsp.ContentLength < 0)
 
 		// Small request using Encode(): should not be chunked
 		sendRsp = NewResponse(req)
@@ -582,6 +585,8 @@ func TestE2EFullDuplex(t *testing.T) {
 		req.Body = Streamer()
 		defer req.Body.Close()
 		rsp := req.Send().Response()
+		assert.True(t, rsp.ContentLength < 0)
+
 		for i := 0; i < 50; i++ {
 			b := []byte(fmt.Sprintf("foo %d", i))
 			if i%2 == 0 { // Alternate between sending a chunk in the request body, and sending it "directly"
@@ -595,6 +600,8 @@ func TestE2EFullDuplex(t *testing.T) {
 			assert.Equal(t, b, bb)
 		}
 		close(chunks)
+
+		assert.True(t, rsp.ContentLength < 0)
 	})
 }
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -369,7 +369,7 @@ func TestE2EProxiedStreamer(t *testing.T) {
 		if !rsp.ProtoAtLeast(2, 0) {
 			assert.Contains(t, rsp.TransferEncoding, "chunked")
 		}
-		assert.EqualValues(t,-1, rsp.ContentLength)
+		assert.EqualValues(t, -1, rsp.ContentLength)
 		for i := 0; i < 100; i++ {
 			chunks <- true
 			b := make([]byte, 500)

--- a/request.go
+++ b/request.go
@@ -94,7 +94,7 @@ func (r *Request) Write(b []byte) (n int, err error) {
 		r.Body = buf
 		n, err = buf.Write(b)
 		if err != nil {
-			return 0, err
+			return n, err
 		}
 	}
 

--- a/request.go
+++ b/request.go
@@ -77,7 +77,7 @@ func (r *Request) Write(b []byte) (n int, err error) {
 	case io.Writer:
 		n, err = rc.Write(b)
 		if err != nil {
-			return 0, err
+			return n, err
 		}
 	// If a caller manually sets Response.Body, then we may not be able to write to it. In that case, we need to be
 	// cleverer.

--- a/request.go
+++ b/request.go
@@ -54,9 +54,7 @@ func (r *Request) Encode(v interface{}) {
 		return
 	}
 
-	cw := &countingWriter{
-		Writer: r}
-	if err := json.NewEncoder(cw).Encode(v); err != nil {
+	if err := json.NewEncoder(r).Encode(v); err != nil {
 		r.err = terrors.Wrap(err, nil)
 		return
 	}

--- a/response.go
+++ b/response.go
@@ -41,16 +41,11 @@ func (r *Response) Encode(v interface{}) {
 		return
 	}
 
-	cw := &countingWriter{
-		Writer: r}
-	if err := json.NewEncoder(cw).Encode(v); err != nil {
+	if err := json.NewEncoder(r).Encode(v); err != nil {
 		r.Error = terrors.Wrap(err, nil)
 		return
 	}
 	r.Header.Set("Content-Type", "application/json")
-	if r.ContentLength < 0 && cw.n < chunkThreshold {
-		r.ContentLength = int64(cw.n)
-	}
 }
 
 // Decode de-serialises the JSON body into the passed object.

--- a/response.go
+++ b/response.go
@@ -96,7 +96,7 @@ func (r *Response) Write(b []byte) (n int, err error) {
 		r.Body = buf
 		n, err = buf.Write(b)
 		if err != nil {
-			return 0, err
+			return n, err
 		}
 	}
 

--- a/response.go
+++ b/response.go
@@ -79,7 +79,7 @@ func (r *Response) Write(b []byte) (n int, err error) {
 	case io.Writer:
 		n, err = rc.Write(b)
 		if err != nil {
-			return 0, err
+			return n, err
 		}
 	// If a caller manually sets Response.Body, then we may not be able to write to it. In that case, we need to be
 	// cleverer.

--- a/response.go
+++ b/response.go
@@ -110,7 +110,7 @@ func (r *Response) Write(b []byte) (n int,err  error) {
 			r.ContentLength = -1
 		}
 	}
-	return n, err
+	return n, nil
 }
 
 // BodyBytes fully reads the response body and returns the bytes read. If consume is false, the body is copied into a

--- a/response_test.go
+++ b/response_test.go
@@ -22,6 +22,7 @@ func TestResponseWriter(t *testing.T) {
 	r.Write([]byte("boop"))
 	b, _ := r.BodyBytes(true)
 	assert.Equal(t, []byte("boop"), b)
+	assert.Equal(t, r.ContentLength, int64(4))
 
 	// Using NewResponse, via ResponseWriter
 	r = NewResponse(req)
@@ -30,6 +31,7 @@ func TestResponseWriter(t *testing.T) {
 	r.Writer().Write([]byte("boop"))
 	b, _ = r.BodyBytes(true)
 	assert.Equal(t, []byte("boop"), b)
+	assert.Equal(t, r.ContentLength, int64(4))
 	assert.Equal(t, http.StatusForbidden, r.StatusCode)
 	assert.Equal(t, "def", r.Header.Get("abc"))
 
@@ -39,6 +41,7 @@ func TestResponseWriter(t *testing.T) {
 	r.Writer().Write([]byte("woop"))
 	b, _ = r.BodyBytes(true)
 	assert.Equal(t, []byte("boopwoop"), b)
+	assert.Equal(t, r.ContentLength, int64(8))
 }
 
 func TestResponseWriter_Error(t *testing.T) {

--- a/response_test.go
+++ b/response_test.go
@@ -22,7 +22,7 @@ func TestResponseWriter(t *testing.T) {
 	r.Write([]byte("boop"))
 	b, _ := r.BodyBytes(true)
 	assert.Equal(t, []byte("boop"), b)
-	assert.Equal(t, r.ContentLength, int64(4))
+	assert.EqualValues(t, 4, r.ContentLength)
 
 	// Using NewResponse, via ResponseWriter
 	r = NewResponse(req)
@@ -31,7 +31,7 @@ func TestResponseWriter(t *testing.T) {
 	r.Writer().Write([]byte("boop"))
 	b, _ = r.BodyBytes(true)
 	assert.Equal(t, []byte("boop"), b)
-	assert.Equal(t, r.ContentLength, int64(4))
+	assert.EqualValues(t,  4, r.ContentLength)
 	assert.Equal(t, http.StatusForbidden, r.StatusCode)
 	assert.Equal(t, "def", r.Header.Get("abc"))
 
@@ -41,7 +41,7 @@ func TestResponseWriter(t *testing.T) {
 	r.Writer().Write([]byte("woop"))
 	b, _ = r.BodyBytes(true)
 	assert.Equal(t, []byte("boopwoop"), b)
-	assert.Equal(t, r.ContentLength, int64(8))
+	assert.EqualValues(t, 8, r.ContentLength)
 }
 
 func TestResponseWriter_Error(t *testing.T) {

--- a/response_test.go
+++ b/response_test.go
@@ -31,7 +31,7 @@ func TestResponseWriter(t *testing.T) {
 	r.Writer().Write([]byte("boop"))
 	b, _ = r.BodyBytes(true)
 	assert.Equal(t, []byte("boop"), b)
-	assert.EqualValues(t,  4, r.ContentLength)
+	assert.EqualValues(t, 4, r.ContentLength)
 	assert.Equal(t, http.StatusForbidden, r.StatusCode)
 	assert.Equal(t, "def", r.Header.Get("abc"))
 


### PR DESCRIPTION
Try to set content length correctly when using `Write()` and `Writer()` methods; only use chunked encoding with content length of -1 when the length is large, or when the handler specifically sets the body to a streamer or another io.Reader. Since the HTTP2 changes were merged, `rsp.Write([]byte("hello"))` would have content length set at -1, and chunked encoding would be used. This led to regressions where callers weren't happy with chunked encoding.