### PR TITLE
Use custom type for router context key

### DIFF
--- a/router.go
+++ b/router.go
@@ -9,8 +9,13 @@ import (
 	"github.com/monzo/terrors"
 )
 
+// We use a custom type to guarantee we won't get a collision with another package. Using an anonymous struct type
+// directly means we'd get a collision with any other package that does the same.
+// https://play.golang.org/p/MxhRiL37R-9
+type routerContextKeyType struct{}
+
 var (
-	routerContextKey   = struct{}{}
+	routerContextKey   = routerContextKeyType{}
 	routerComponentsRe = regexp.MustCompile(`(?:^|/)(\*\w*|:\w+)`)
 )
 


### PR DESCRIPTION
When a typhon router handles a request it adds a reference to itself (the router) into the context within the request. This is useful in a variety of contexts, for example we want to tag metrics with the router pattern that the request was matched against (using the path directly can result in a cardinality explosion if the path is dynamic).

Prior to this pull request we used a context key that was an anonymous empty struct however we observed panics after a filter was introduced within our code base that uses the same key. By using a type definition that is itself an empty struct we avoid this collision.