### PR TITLE
Update tested Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 go:
   - 1.10.x
   - 1.11.x
+  - 1.12.x
+  - 1.13.x
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin


### PR DESCRIPTION
Add Go 1.12 + 1.13 to the versions that are tested by Travis.