### PR TITLE
ineffectual assignment to err

### DIFF
--- a/response.go
+++ b/response.go
@@ -50,10 +50,11 @@ func (r *Response) Encode(v interface{}) {
 
 // Decode de-serialises the JSON body into the passed object.
 func (r *Response) Decode(v interface{}) error {
-	err := error(nil)
 	if r.Error != nil {
 		return r.Error
-	} else if r.Response == nil {
+	}
+	err := error(nil)
+	if r.Response == nil {
 		err = terrors.InternalService("", "Response has no body", nil)
 	} else {
 		var b []byte


### PR DESCRIPTION
It is a bad practice to set variables that will not be used later. Especially in a encoder/decoder that is possibly used frequently.

The variable `err := error(nil)` should be set after the possible return of `r.Error` otherwise it might end up not being used at all.

