### PR TITLE
[EXPERIMENTAL] Support HTTP2 prior knowledge client

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,10 +1,14 @@
 package typhon
 
 import (
+	"context"
+	"crypto/tls"
+	"net"
 	"net/http"
 	"time"
 
 	"github.com/monzo/terrors"
+	"golang.org/x/net/http2"
 )
 
 var (
@@ -12,12 +16,24 @@ var (
 	// takes place; access is not synchronised.
 	Client Service = BareClient
 	// RoundTripper is used by default in Typhon clients
-	RoundTripper http.RoundTripper = &http.Transport{
+	// For cleartext requests, it chooses HTTP1, or H2C based on a context flag (see WithH2C)
+	RoundTripper http.RoundTripper = dynamicRoundTripper{}
+	// HTTPRoundTripper is a HTTP1 and TLS HTTP2 client
+	HTTPRoundTripper http.RoundTripper = &http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
 		DisableKeepAlives:   false,
 		DisableCompression:  false,
 		IdleConnTimeout:     10 * time.Minute,
 		MaxIdleConnsPerHost: 10}
+	// H2CRoundTripper is a prior-knowledge H2C client. It does not support ProxyFromEnvironment.
+	H2CRoundTripper http.RoundTripper = &http2.Transport{
+		AllowHTTP: true,
+		// This monstrosity is needed to get the http2 Transport to dial over cleartext.
+		// See https://github.com/thrawn01/h2c-golang-example
+		DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
+			return net.Dial(network, addr)
+		},
+	}
 )
 
 // A ResponseFuture is a container for a Response which will materialise at some point.
@@ -90,4 +106,25 @@ func SendVia(req Request, svc Service) *ResponseFuture {
 //  SendVia(req, Client)
 func Send(req Request) *ResponseFuture {
 	return SendVia(req, Client)
+}
+
+type withH2C struct{}
+
+// WithH2C instructs the dynamicRoundTripper to use prior-knowledge cleartext HTTP2 instead of HTTP1.1
+func WithH2C(ctx context.Context) context.Context {
+	return context.WithValue(ctx, withH2C{}, true)
+}
+
+func isH2C(ctx context.Context) bool {
+	b, _ := ctx.Value(withH2C{}).(bool)
+	return b
+}
+
+type dynamicRoundTripper struct{}
+
+func (d dynamicRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Scheme == "http" && isH2C(r.Context()) {
+		return H2CRoundTripper.RoundTrip(r)
+	}
+	return HTTPRoundTripper.RoundTrip(r)
 }

--- a/e2e_http1_test.go
+++ b/e2e_http1_test.go
@@ -1,6 +1,7 @@
 package typhon
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"testing"
@@ -26,6 +27,10 @@ func (f http1Flavour) Proto() string {
 	return "HTTP/1.1"
 }
 
+func (f http1Flavour) Context() (context.Context, func()) {
+	return context.WithCancel(context.Background())
+}
+
 type http1TLSFlavour struct {
 	T    *testing.T
 	cert tls.Certificate
@@ -47,4 +52,8 @@ func (f http1TLSFlavour) URL(s *Server) string {
 
 func (f http1TLSFlavour) Proto() string {
 	return "HTTP/1.1"
+}
+
+func (f http1TLSFlavour) Context() (context.Context, func()) {
+	return context.WithCancel(context.Background())
 }

--- a/e2e_http2_test.go
+++ b/e2e_http2_test.go
@@ -1,6 +1,7 @@
 package typhon
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"testing"
@@ -28,6 +29,12 @@ func (f http2H2cFlavour) Proto() string {
 	return "HTTP/2.0"
 }
 
+func (f http2H2cFlavour) Context() (context.Context, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = WithH2C(ctx)
+	return ctx, cancel
+}
+
 type http2H2Flavour struct {
 	T      *testing.T
 	client Service
@@ -51,4 +58,8 @@ func (f http2H2Flavour) URL(s *Server) string {
 
 func (f http2H2Flavour) Proto() string {
 	return "HTTP/2.0"
+}
+
+func (f http2H2Flavour) Context() (context.Context, func()) {
+	return context.WithCancel(context.Background())
 }


### PR DESCRIPTION
Allow the use of an HTTP2 prior knowledge client, as indicated by a context flag.

Prior Knowledge connections are discussed in [section 3.4 of the HTTP/2 RFC](https://tools.ietf.org/html/rfc7540#section-3.4):

```
A client can learn that a particular server supports HTTP/2 by other
means.  For example, [ALT-SVC] describes a mechanism for advertising
this capability.

A client MUST send the connection preface (Section 3.5) and then MAY
immediately send HTTP/2 frames to such a server; servers can identify
these connections by the presence of the connection preface. This
only affects the establishment of HTTP/2 connections over cleartext
TCP; implementations that support HTTP/2 over TLS MUST use protocol
negotiation in TLS [TLS-ALPN].

Likewise, the server MUST send a connection preface (Section 3.5).

Without additional information, prior support for HTTP/2 is not a
strong signal that a given server will support HTTP/2 for future
connections.  For example, it is possible for server configurations
to change, for configurations to differ between instances in
clustered servers, or for network conditions to change.
```