### PR TITLE
[BP-513] Add support for wrapping downstream request errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -51,7 +51,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3a69e64d3da7280a8791a2babbe8fd1f80827c98d6bed0258147efb1dad327a6"
+  digest = "1:556e3018b354ca239202d8eaed2879aa040ec054394a7b5f357a0d47a0edb6c3"
   name = "github.com/monzo/terrors"
   packages = [
     ".",
@@ -59,7 +59,7 @@
     "stack",
   ]
   pruneopts = "UT"
-  revision = "203c0c1e55e771e98136e84e1c666177e1cc79bf"
+  revision = "81358a97541825942f894e1fad7846001042ec00"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -51,7 +51,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:556e3018b354ca239202d8eaed2879aa040ec054394a7b5f357a0d47a0edb6c3"
+  digest = "1:3d266ca56d034876390fc2137f7b3f7b49eac4b518d19c57baba55f47f239976"
   name = "github.com/monzo/terrors"
   packages = [
     ".",
@@ -59,7 +59,7 @@
     "stack",
   ]
   pruneopts = "UT"
-  revision = "81358a97541825942f894e1fad7846001042ec00"
+  revision = "856ac917ee84f6fa3ad07ad353030adabb02a55c"
 
 [[projects]]
   branch = "master"

--- a/response.go
+++ b/response.go
@@ -48,9 +48,21 @@ func (r *Response) Encode(v interface{}) {
 	r.Header.Set("Content-Type", "application/json")
 }
 
+// MaskDownstreamErrors is a context key that can be used to enable
+// wrapping of downstream response errors on a per-request basis.
+//
+// This is implemented as a context key to allow us to migrate individual
+// services from the old behaviour to the new behaviour without adding a
+// dependency on config to Typhon.
+type MaskDownstreamErrors struct{}
+
 // Decode de-serialises the JSON body into the passed object.
 func (r *Response) Decode(v interface{}) error {
 	if r.Error != nil {
+		if s, ok := r.Request.Context.Value(MaskDownstreamErrors{}).(string); ok && s != "" {
+			return terrors.NewInternalWithCause(r.Error, "Downstream request error", nil, "downstream")
+		}
+
 		return r.Error
 	}
 	err := error(nil)

--- a/response.go
+++ b/response.go
@@ -48,18 +48,18 @@ func (r *Response) Encode(v interface{}) {
 	r.Header.Set("Content-Type", "application/json")
 }
 
-// MaskDownstreamErrors is a context key that can be used to enable
+// WrapDownstreamErrors is a context key that can be used to enable
 // wrapping of downstream response errors on a per-request basis.
 //
 // This is implemented as a context key to allow us to migrate individual
 // services from the old behaviour to the new behaviour without adding a
 // dependency on config to Typhon.
-type MaskDownstreamErrors struct{}
+type WrapDownstreamErrors struct{}
 
 // Decode de-serialises the JSON body into the passed object.
 func (r *Response) Decode(v interface{}) error {
 	if r.Error != nil {
-		if s, ok := r.Request.Context.Value(MaskDownstreamErrors{}).(string); ok && s != "" {
+		if s, ok := r.Request.Context.Value(WrapDownstreamErrors{}).(string); ok && s != "" {
 			return terrors.NewInternalWithCause(r.Error, "Downstream request error", nil, "downstream")
 		}
 

--- a/response.go
+++ b/response.go
@@ -59,8 +59,10 @@ type WrapDownstreamErrors struct{}
 // Decode de-serialises the JSON body into the passed object.
 func (r *Response) Decode(v interface{}) error {
 	if r.Error != nil {
-		if s, ok := r.Request.Context.Value(WrapDownstreamErrors{}).(string); ok && s != "" {
-			return terrors.NewInternalWithCause(r.Error, "Downstream request error", nil, "downstream")
+		if r.Request != nil && r.Request.Context != nil {
+			if s, ok := r.Request.Context.Value(WrapDownstreamErrors{}).(string); ok && s != "" {
+				return terrors.NewInternalWithCause(r.Error, "Downstream request error", nil, "downstream")
+			}
 		}
 
 		return r.Error

--- a/response_test.go
+++ b/response_test.go
@@ -64,6 +64,12 @@ func TestResponse_WrapDownstreamErrors(t *testing.T) {
 		expectedErrCode string
 	}{
 		{
+			desc:            "missing context",
+			ctx:             nil,
+			downstreamErr:   terrors.NotFound("foo", "not found", nil),
+			expectedErrCode: "not_found.foo",
+		},
+		{
 			desc:            "wrap downstream errors not set",
 			ctx:             context.Background(),
 			downstreamErr:   terrors.NotFound("foo", "not found", nil),
@@ -97,6 +103,14 @@ func TestResponse_WrapDownstreamErrors(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestResponse_WrapDownstreamErrorsWithoutRequest(t *testing.T) {
+	// It's possible to create a Response without a Request.
+	// This test ensures that we don't panic when trying to read from the context.
+	err := terrors.NotFound("foo", "not found", nil)
+	rsp := Response{Error: err}
+	assert.Equal(t, err, rsp.Decode(nil))
 }
 
 // TestResponseDecodeCloses verifies that a response body is closed after calling Decode()

--- a/response_test.go
+++ b/response_test.go
@@ -55,7 +55,7 @@ func TestResponseWriter_Error(t *testing.T) {
 	assert.Equal(t, "abc", rsp.Error.Error())
 }
 
-func TestResponse_MaskDownstreamErrors(t *testing.T) {
+func TestResponse_WrapDownstreamErrors(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		desc            string
@@ -64,20 +64,20 @@ func TestResponse_MaskDownstreamErrors(t *testing.T) {
 		expectedErrCode string
 	}{
 		{
-			desc:            "mask downstream errors not set",
+			desc:            "wrap downstream errors not set",
 			ctx:             context.Background(),
 			downstreamErr:   terrors.NotFound("foo", "not found", nil),
 			expectedErrCode: "not_found.foo",
 		},
 		{
-			desc:            "mask downstream errors set",
-			ctx:             context.WithValue(context.Background(), MaskDownstreamErrors{}, "1"),
+			desc:            "wrap downstream errors set",
+			ctx:             context.WithValue(context.Background(), WrapDownstreamErrors{}, "1"),
 			downstreamErr:   terrors.NotFound("foo", "not found", nil),
 			expectedErrCode: "internal_service.downstream",
 		},
 		{
-			desc:            "mask downstream errors empty",
-			ctx:             context.WithValue(context.Background(), MaskDownstreamErrors{}, ""),
+			desc:            "wrap downstream errors empty",
+			ctx:             context.WithValue(context.Background(), WrapDownstreamErrors{}, ""),
 			downstreamErr:   terrors.NotFound("foo", "not found", nil),
 			expectedErrCode: "not_found.foo",
 		},

--- a/vendor/github.com/monzo/terrors/.travis.yml
+++ b/vendor/github.com/monzo/terrors/.travis.yml
@@ -1,13 +1,13 @@
 language: go
 
 go:
-  - 1.8.x
-  - 1.9.x
+  - 1.13.x
+  - 1.14.x
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin
   - go get -v -t ./...
-  - go get -v github.com/golang/lint/golint
+  - go get -v golang.org/x/lint/golint
 
 before_script:
   - go vet ./...

--- a/vendor/github.com/monzo/terrors/factory.go
+++ b/vendor/github.com/monzo/terrors/factory.go
@@ -1,0 +1,113 @@
+package terrors
+
+import (
+	"strings"
+
+	"github.com/monzo/terrors/stack"
+)
+
+// Wrap takes any error interface and wraps it into an Error.
+// This is useful because an Error contains lots of useful goodies, like the stacktrace of the error.
+// NOTE: If `err` is already an `Error`, it will add the params passed in to the params of the Error
+func Wrap(err error, params map[string]string) error {
+	return WrapWithCode(err, params, ErrInternalService)
+}
+
+// WrapWithCode wraps an error with a custom error code. If `err` is already
+// an `Error`, it will add the params passed in to the params of the error
+func WrapWithCode(err error, params map[string]string, code string) error {
+	if err == nil {
+		return nil
+	}
+	switch err := err.(type) {
+	case *Error:
+		return addParams(err, params)
+	default:
+		return errorFactory(code, err.Error(), params)
+	}
+}
+
+// InternalService creates a new error to represent an internal service error.
+// Only use internal service error if we know very little about the error. Most
+// internal service errors will come from `Wrap`ing a vanilla `error` interface
+func InternalService(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrInternalService, code), message, params)
+}
+
+// BadRequest creates a new error to represent an error caused by the client sending
+// an invalid request. This is non-retryable unless the request is modified.
+func BadRequest(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrBadRequest, code), message, params)
+}
+
+// BadResponse creates a new error representing a failure to response with a valid response
+// Examples of this would be a handler returning an invalid message format
+func BadResponse(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrBadResponse, code), message, params)
+}
+
+// Timeout creates a new error representing a timeout from client to server
+func Timeout(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrTimeout, code), message, params)
+}
+
+// NotFound creates a new error representing a resource that cannot be found. In some
+// cases this is not an error, and would be better represented by a zero length slice of elements
+func NotFound(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrNotFound, code), message, params)
+}
+
+// Forbidden creates a new error representing a resource that cannot be accessed with
+// the current authorisation credentials. The user may need authorising, or if authorised,
+// may not be permitted to perform this action
+func Forbidden(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrForbidden, code), message, params)
+}
+
+// Unauthorized creates a new error indicating that authentication is required,
+// but has either failed or not been provided.
+func Unauthorized(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrUnauthorized, code), message, params)
+}
+
+// PreconditionFailed creates a new error indicating that one or more conditions
+// given in the request evaluated to false when tested on the server.
+func PreconditionFailed(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrPreconditionFailed, code), message, params)
+}
+
+// errorConstructor returns a `*Error` with the specified code, message and params.
+// Builds a stack based on the current call stack
+func errorFactory(code string, message string, params map[string]string) *Error {
+	err := &Error{
+		Code:    ErrUnknown,
+		Message: message,
+		Params:  map[string]string{},
+	}
+	if len(code) > 0 {
+		err.Code = code
+	}
+	if params != nil {
+		err.Params = params
+	}
+
+	// TODO pass in context.Context
+
+	// Build stack and skip first three lines:
+	//  - stack.go BuildStack()
+	//  - errors.go errorFactory()
+	//  - errors.go public constructor method
+	err.StackFrames = stack.BuildStack(3)
+
+	return err
+}
+
+func errCode(prefix, code string) string {
+	if code == "" {
+		return prefix
+	}
+	if prefix == "" {
+		return code
+	}
+	return strings.Join([]string{prefix, code}, ".")
+}

--- a/vendor/github.com/monzo/terrors/stack/stack.go
+++ b/vendor/github.com/monzo/terrors/stack/stack.go
@@ -19,9 +19,10 @@ var (
 )
 
 type Frame struct {
-	Filename string `json:"filename"`
-	Method   string `json:"method"`
-	Line     int    `json:"lineno"`
+	Filename string  `json:"filename"`
+	Method   string  `json:"method"`
+	Line     int     `json:"lineno"`
+	PC       uintptr `json:"pc"`
 }
 
 type Stack []*Frame
@@ -50,6 +51,7 @@ func BuildStack(skip int) Stack {
 			Filename: shortenFilePath(frame.File),
 			Method:   functionName(frame.PC),
 			Line:     frame.Line,
+			PC:       frame.PC,
 		})
 		if !ok {
 			// This was the last valid caller


### PR DESCRIPTION
This PR adds support for wrapping downstream errors in the `Response` `.Decode` method.

Our goal here is to prevent downstream errors from propagating across service boundaries by default. This would mean that downstream `not_found` errors are converted into `internal_service` errors by default (with the underlying `not_found` error preserved as a _cause_ on the newly created error).

The implementation uses a context value to introduce this behaviour in a way that makes it configurable for callers. We'd like to experiment with this behaviour in our own services before recommending it and so we need to be able to enable it on a per-service basis.

We tried first to implement this as a filter, however, when creating a new error within a filter the stack trace doesn't include the entire call stack because the filter is executed in a separate go routine. Adding this code at the point when `Decode` is called ensures that the stack trace includes the entire call stack.

We also considered implementing this behaviour outside of Typhon in the generated client code for each service. However, that requires introducing a config dependency into all of the generated clients and regenerating them.

The approach in this PR feels like the most practical way to enable this feature on a per-service basis, even though it feels like somewhat of an abuse of the context field (to influence control flow in the library).

https://mondough.atlassian.net/browse/BP-513