### PR TITLE
Update terrors, add RateLimited mapping

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -51,7 +51,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6992c123a5662baa0d874a3580d2a75504b763dfc1b7e53e2d646f6ae61a9562"
+  digest = "1:5c42a5e5384005b921c1fc62378e60e68735a2d66f9482afddbe835b69c1c6ec"
   name = "github.com/monzo/terrors"
   packages = [
     ".",
@@ -59,7 +59,7 @@
     "stack",
   ]
   pruneopts = "UT"
-  revision = "1b34fb1ca9c30f91ae33037d87c790cae8bdc513"
+  revision = "526801726c25137e6d1cd1a1aade1c3da27e6809"
 
 [[projects]]
   branch = "master"

--- a/errors.go
+++ b/errors.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/monzo/slog"
 	"github.com/monzo/terrors"
-	"github.com/monzo/terrors/proto"
+	terrorsproto "github.com/monzo/terrors/proto"
 )
 
 var (
@@ -22,6 +22,7 @@ var (
 		terrors.ErrPreconditionFailed: http.StatusPreconditionFailed,  // 412
 		terrors.ErrTimeout:            http.StatusGatewayTimeout,      // 504
 		terrors.ErrUnauthorized:       http.StatusUnauthorized,        // 401
+		terrors.ErrRateLimited:        http.StatusTooManyRequests,     // 429
 	}
 	mapStatus2Terr map[int]string
 )

--- a/vendor/github.com/monzo/terrors/errors.go
+++ b/vendor/github.com/monzo/terrors/errors.go
@@ -24,6 +24,27 @@ import (
 	"github.com/monzo/terrors/stack"
 )
 
+// Generic error codes. Each of these has their own constructor for convenience.
+// You can use any string as a code, just use the `New` method.
+const (
+	ErrBadRequest         = "bad_request"
+	ErrBadResponse        = "bad_response"
+	ErrForbidden          = "forbidden"
+	ErrInternalService    = "internal_service"
+	ErrNotFound           = "not_found"
+	ErrPreconditionFailed = "precondition_failed"
+	ErrTimeout            = "timeout"
+	ErrUnauthorized       = "unauthorized"
+	ErrUnknown            = "unknown"
+	ErrRateLimited        = "rate_limited"
+)
+
+var retryableCodes = []string{
+	ErrInternalService,
+	ErrTimeout,
+	ErrUnknown,
+}
+
 // Error is terror's error. It implements Go's error interface.
 type Error struct {
 	Code        string            `json:"code"`
@@ -41,26 +62,6 @@ type Error struct {
 	// should not expect it to contain information about terrors from other downstream
 	// processes.
 	cause error
-}
-
-// Generic error codes. Each of these has their own constructor for convenience.
-// You can use any string as a code, just use the `New` method.
-const (
-	ErrBadRequest         = "bad_request"
-	ErrBadResponse        = "bad_response"
-	ErrForbidden          = "forbidden"
-	ErrInternalService    = "internal_service"
-	ErrNotFound           = "not_found"
-	ErrPreconditionFailed = "precondition_failed"
-	ErrTimeout            = "timeout"
-	ErrUnauthorized       = "unauthorized"
-	ErrUnknown            = "unknown"
-)
-
-var retryableCodes = []string{
-	ErrInternalService,
-	ErrTimeout,
-	ErrUnknown,
 }
 
 // Error returns a string message of the error.

--- a/vendor/github.com/monzo/terrors/factory.go
+++ b/vendor/github.com/monzo/terrors/factory.go
@@ -79,6 +79,12 @@ func PreconditionFailed(code, message string, params map[string]string) *Error {
 	return errorFactory(errCode(ErrPreconditionFailed, code), message, params)
 }
 
+// RateLimited creates a new error indicating that the request has been rate-limited,
+// and that the caller should back-off.
+func RateLimited(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrRateLimited, code), message, params)
+}
+
 // errorConstructor returns a `*Error` with the specified code, message and params.
 // Builds a stack based on the current call stack
 func errorFactory(code string, message string, params map[string]string) *Error {


### PR DESCRIPTION
This updates `typhon` to understand the the `RateLimited` error from terrors, and maps it to an HTTP 429.