### PR TITLE
Add support for setting metadata through context

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,32 @@
+package typhon
+
+import "context"
+
+type metadataKey struct{}
+
+// Metadata provides a transport agnostic way to pass metadata with Typhon.
+// It aligns to the interface of Go's default HTTP header type for convenience.
+type Metadata map[string][]string
+
+// NewMetadata creates a metadata struct from a map of strings.
+func NewMetadata(data map[string]string) Metadata {
+	meta := make(Metadata, len(data))
+	for k, v := range data {
+		meta[k] = []string{v}
+	}
+	return meta
+}
+
+// AppendMetadataToContext sets the metadata on the context.
+func AppendMetadataToContext(ctx context.Context, md Metadata) context.Context {
+	return context.WithValue(ctx, metadataKey{}, md)
+}
+
+// MetadataFromContext retrieves the metadata from the context.
+func MetadataFromContext(ctx context.Context) Metadata {
+	meta, ok := ctx.Value(metadataKey{}).(Metadata)
+	if !ok {
+		return Metadata{}
+	}
+	return meta
+}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,27 @@
+package typhon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetadataRoundtrip(t *testing.T) {
+	meta := NewMetadata(map[string]string{
+		"meta": "data",
+	})
+	ctx := context.Background()
+
+	withMeta := AppendMetadataToContext(ctx, meta)
+	out := MetadataFromContext(withMeta)
+
+	assert.Equal(t, meta, out)
+}
+
+func TestMetadataNotSet(t *testing.T) {
+	meta := NewMetadata(map[string]string{})
+	out := MetadataFromContext(context.Background())
+
+	assert.Equal(t, meta, out)
+}

--- a/request.go
+++ b/request.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/monzo/terrors"
 )
@@ -175,6 +176,12 @@ func NewRequest(ctx context.Context, method, url string, body interface{}) Reque
 		httpReq.ContentLength = 0
 		httpReq.Body = &bufCloser{}
 		req.Request = *httpReq
+
+		// Attach any metadata in the context to the request as headers.
+		meta := MetadataFromContext(ctx)
+		for k, v := range meta {
+			req.Header[strings.ToLower(k)] = v
+		}
 	}
 	if body != nil && err == nil {
 		req.Encode(body)

--- a/request_test.go
+++ b/request_test.go
@@ -2,6 +2,7 @@ package typhon
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -60,4 +61,16 @@ func TestRequestEncodeReader(t *testing.T) {
 	body, err = ioutil.ReadAll(req.Body)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("{}\n"), body)
+}
+
+func TestRequestSetMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := AppendMetadataToContext(context.Background(), NewMetadata(map[string]string{
+		"meta": "data",
+	}))
+
+	req := NewRequest(ctx, "GET", "/", nil)
+
+	assert.Equal(t, []string{"data"}, req.Request.Header["meta"])
 }


### PR DESCRIPTION
This allows us to attach and to retrieve metadata on a Typhon request by use of the context. This is useful for scenarios when the caller doesn't have direct access to the underlying HTTP request.