### PR TITLE
Add ResponseWithCode method to Typhon request

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -66,7 +66,7 @@ func ErrorFilter(req Request, svc Service) Response {
 	}
 
 	if rsp.Response == nil {
-		rsp.Response = newHTTPResponse(req)
+		rsp.Response = newHTTPResponse(req, http.StatusOK)
 	}
 	if rsp.Request == nil {
 		rsp.Request = &req

--- a/request.go
+++ b/request.go
@@ -147,9 +147,19 @@ func (r Request) SendVia(svc Service) *ResponseFuture {
 	return SendVia(r, svc)
 }
 
-// Response construct a new Response to the request, and if non-nil, encodes the given body into it.
+// Response constructs a new Response to the request, and if non-nil, encodes the given body into it.
 func (r Request) Response(body interface{}) Response {
 	rsp := NewResponse(r)
+	if body != nil {
+		rsp.Encode(body)
+	}
+	return rsp
+}
+
+// ResponseWithCode constructs a new Response with the given status code to the request, and if non-nil, encodes the
+// given body into it.
+func (r Request) ResponseWithCode(body interface{}, statusCode int) Response {
+	rsp := NewResponseWithCode(r, statusCode)
 	if body != nil {
 		rsp.Encode(body)
 	}

--- a/response.go
+++ b/response.go
@@ -25,7 +25,7 @@ type Response struct {
 // Encode serialises the passed object as JSON into the body (and sets appropriate headers).
 func (r *Response) Encode(v interface{}) {
 	if r.Response == nil {
-		r.Response = newHTTPResponse(Request{})
+		r.Response = newHTTPResponse(Request{}, http.StatusOK)
 	}
 
 	// If we were given an io.ReadCloser or an io.Reader (that is not also a json.Marshaler), use it directly
@@ -87,7 +87,7 @@ func (r *Response) Decode(v interface{}) error {
 // Write writes the passed bytes to the response's body.
 func (r *Response) Write(b []byte) (n int, err error) {
 	if r.Response == nil {
-		r.Response = newHTTPResponse(Request{})
+		r.Response = newHTTPResponse(Request{}, http.StatusOK)
 	}
 	switch rc := r.Body.(type) {
 	// In the "regular" case, the response body will be a bufCloser; we can write
@@ -178,9 +178,9 @@ func (r Response) String() string {
 	return b.String()
 }
 
-func newHTTPResponse(req Request) *http.Response {
+func newHTTPResponse(req Request, statusCode int) *http.Response {
 	return &http.Response{
-		StatusCode:    http.StatusOK, // Seems like a reasonable default
+		StatusCode:    statusCode,
 		Proto:         req.Proto,
 		ProtoMajor:    req.ProtoMajor,
 		ProtoMinor:    req.ProtoMinor,
@@ -194,5 +194,5 @@ func NewResponse(req Request) Response {
 	return Response{
 		Request:  &req,
 		Error:    nil,
-		Response: newHTTPResponse(req)}
+		Response: newHTTPResponse(req, http.StatusOK)}
 }

--- a/response.go
+++ b/response.go
@@ -191,10 +191,7 @@ func newHTTPResponse(req Request, statusCode int) *http.Response {
 
 // NewResponse constructs a Response with status code 200.
 func NewResponse(req Request) Response {
-	return Response{
-		Request:  &req,
-		Error:    nil,
-		Response: newHTTPResponse(req, http.StatusOK)}
+	return NewResponseWithCode(req, http.StatusOK)
 }
 
 // NewResponseWithCode constructs a Response with the given status code.

--- a/response.go
+++ b/response.go
@@ -189,10 +189,18 @@ func newHTTPResponse(req Request, statusCode int) *http.Response {
 		Body:          &bufCloser{}}
 }
 
-// NewResponse constructs a Response
+// NewResponse constructs a Response with status code 200.
 func NewResponse(req Request) Response {
 	return Response{
 		Request:  &req,
 		Error:    nil,
 		Response: newHTTPResponse(req, http.StatusOK)}
+}
+
+// NewResponseWithCode constructs a Response with the given status code.
+func NewResponseWithCode(req Request, statusCode int) Response {
+	return Response{
+		Request:  &req,
+		Error:    nil,
+		Response: newHTTPResponse(req, statusCode)}
 }

--- a/response_test.go
+++ b/response_test.go
@@ -26,6 +26,7 @@ func TestResponseWriter(t *testing.T) {
 	b, _ := r.BodyBytes(true)
 	assert.Equal(t, []byte("boop"), b)
 	assert.EqualValues(t, 4, r.ContentLength)
+	assert.Equal(t, http.StatusOK, r.StatusCode)
 
 	// Using NewResponse, via ResponseWriter
 	r = NewResponse(req)
@@ -45,6 +46,39 @@ func TestResponseWriter(t *testing.T) {
 	b, _ = r.BodyBytes(true)
 	assert.Equal(t, []byte("boopwoop"), b)
 	assert.EqualValues(t, 8, r.ContentLength)
+	assert.Equal(t, http.StatusOK, r.StatusCode)
+}
+
+func TestResponseWithCodeWriter(t *testing.T) {
+	t.Parallel()
+	req := Request{}
+
+	// Using NewResponseWithCode, vanilla
+	r := NewResponseWithCode(req, http.StatusCreated)
+	r.Write([]byte("boop"))
+	b, _ := r.BodyBytes(true)
+	assert.Equal(t, []byte("boop"), b)
+	assert.EqualValues(t, 4, r.ContentLength)
+	assert.Equal(t, http.StatusCreated, r.StatusCode)
+
+	// Using NewResponseWithCode, via ResponseWriter
+	r = NewResponseWithCode(req, http.StatusCreated)
+	r.Writer().Header().Set("abc", "def")
+	r.Writer().Write([]byte("boop"))
+	b, _ = r.BodyBytes(true)
+	assert.Equal(t, []byte("boop"), b)
+	assert.EqualValues(t, 4, r.ContentLength)
+	assert.Equal(t, http.StatusCreated, r.StatusCode)
+	assert.Equal(t, "def", r.Header.Get("abc"))
+
+	// Using NewResponseWithCode, vanilla and then ResponseWriter
+	r = NewResponseWithCode(req, http.StatusCreated)
+	r.Write([]byte("boop"))
+	r.Writer().Write([]byte("woop"))
+	b, _ = r.BodyBytes(true)
+	assert.Equal(t, []byte("boopwoop"), b)
+	assert.EqualValues(t, 8, r.ContentLength)
+	assert.Equal(t, http.StatusCreated, r.StatusCode)
 }
 
 func TestResponseWriter_Error(t *testing.T) {


### PR DESCRIPTION
While reading [the proposal for API standards at Monzo](https://www.notion.so/monzo/API-Standards-4f1268b9bb3741749939ea7f16466fd5), I noticed we don't have a method to construct a Typhon response to a request _and_ set its HTTP status code at the same time.

This means that to return specific HTTP status codes from our APIs, the application code needs to set the status code on the response returned by the `Response` method.

For example, the new API standards suggest returning `201 Created` in response to a `PUT` request that creates a new entity. To do this with Typhon, we would write something along these lines:

```
rsp := req.Response(&MyResponseType{})
rsp.StatusCode = http.StatusCreated
return rsp
```

This PR adds a method `ResponseWithCode` to `Request`, so that we could do this instead:

```
return req.Response(&MyResponseType{}, http.StatusCreated)
```

If you feel this could be useful, I'd be happy add comments and tests. Otherwise, if there are reasons not to do this, I'll just close the PR!