### PR TITLE
Enable aborting streamer with error

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -23,8 +23,12 @@ type streamer struct {
 //  func streamingService(req typhon.Request) typhon.Response {
 //      body := typhon.Streamer()
 //      go func() {
-//          defer body.Close()
 //          // do something to asynchronously produce output into body
+//          if err != nil {
+//              body.CloseWithError(err)
+//              return
+//          }
+//          body.Close()
 //      }()
 //      return req.Response(body)
 //  }

--- a/buffer.go
+++ b/buffer.go
@@ -14,6 +14,11 @@ func (b *bufCloser) Close() error {
 	return nil // No-op
 }
 
+type StreamerWriter interface {
+	io.ReadWriteCloser
+	CloseWithError(error) error
+}
+
 type streamer struct {
 	pipeR *io.PipeReader
 	pipeW *io.PipeWriter
@@ -35,7 +40,7 @@ type streamer struct {
 //
 // Note that a Streamer may not perform any internal buffering, so callers should take care not to depend on writes
 // being non-blocking. If buffering is needed, Streamer can be wrapped in a bufio.Writer.
-func Streamer() io.ReadWriteCloser {
+func Streamer() StreamerWriter {
 	pipeR, pipeW := io.Pipe()
 	return &streamer{
 		pipeR: pipeR,

--- a/buffer.go
+++ b/buffer.go
@@ -50,6 +50,10 @@ func (s *streamer) Close() error {
 	return s.pipeW.Close()
 }
 
+func (s *streamer) CloseWithError(err error) error {
+	return s.pipeW.CloseWithError(err)
+}
+
 // doneReader is a wrapper around a ReadCloser which provides notification when the stream has been fully consumed
 // (ie. when EOF is reached, when the reader is explicitly closed, or if the size of the underlying reader is known,
 // when it has been fully read [even if EOF is not reached.])


### PR DESCRIPTION
If a server is using `typhon.Streamer()` and encounters an error that prevents it from writing the next chunk of data to the response (e.g. failed to read the next record from the database), there is currently no way for the server to signal to the client that streaming terminated unsuccessfully. (Besides simply stopping writing and not calling `streamer.Close()` so the client times out (and leaking a goroutine on the server), or encoding some sort of application-level error into the response body). 

For example:

```go
func streamingService(req typhon.Request) typhon.Response {
    body := typhon.Streamer()
    go func() {
        for {
            data, err := readNextData(...)
            if err != nil {
                // what should I do here?
            }
        }
        body.Close()
    }()
    return req.Response(body)
}
```

Not having an obvious blessed path for aborting a streaming response also creates a risk of engineers falling into this pitfall, which would result in the client reading a truncated response:

```go
func streamingService(req typhon.Request) typhon.Response {
    body := typhon.Streamer()
    go func() {
        defer body.Close()
        for {
            data, err := readNextData(...)
            if err != nil {
                return
            }
        }
    }()
    return req.Response(body)
}
```

To fix this, this PR adds a new `streamer.CloseWithError(error)` method, which aborts the HTTP response:

```go
func streamingService(req typhon.Request) typhon.Response {
    body := typhon.Streamer()
    go func() {
        for {
            data, err := readNextData(...)
            if err != nil {
                body.CloseWithError(err)
                return
            }
        }
        body.Close()
    }()
    return req.Response(body)
}
```

Internally, typhon aborts the HTTP response by calling `panic(http.ErrAbortHandler)`, which is the official way to abort an HTTP response within `ServeHTTP` (for HTTP 1.1 and 2). See https://github.com/golang/go/issues/17790.

One thing I'm not sure about is, is it safe to assume the panic would always be caught by `http.conn.serve()` [here](https://github.com/golang/go/blob/master/src/net/http/server.go#L1818)? Is there any risk the panic could be intercepted by some intermediate function (e.g. a filter)?

To expose the `CloseWithError()` method, I had to change `typhon.Streamer()` from returning an `io.ReadWriteCloser` to a `typhon.StreamWriter`. Changing the return type is a breaking change (e.g. if a caller passes the streamer to a function), but I couldn't see any other non-nasty way of doing this.