### PR TITLE
Document the behavior inside ErrorFilter

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -55,24 +55,39 @@ func status2TerrCode(code int) string {
 
 // ErrorFilter serialises and deserialises response errors. Without this filter, errors may not be passed across
 // the network properly so it is recommended to use this in most/all cases.
+// It tries to do everything it can to give you all the information that it can about why your request might have failed.
+// Because of this, it has some weird behavior.
 func ErrorFilter(req Request, svc Service) Response {
-	// If the request contains an error, short-circuit and return that directly
 	var rsp Response
+
+	// If the request contains an error, short-circuit and don't apply the given Service to the request.
+	// req.err being non-nil normally means we got an error trying to constructing the underlying http.Request and so there
+	// is no request to pass through to svc.
 	if req.err != nil {
 		rsp = NewResponse(req)
 		rsp.Error = req.err
 	} else {
+		// rsp.Error could be non-nil. This normally represents an error during the round trip (e.g. connection closed).
+		// It isn't expected to repsent an error received from the remote.
 		rsp = svc(req)
+
+		// If we never got a response then construct a default response. This is only expected to be needed if rsp.Error is non-nil.
+		if rsp.Response == nil {
+			// Status defaults to StatusOK here. It will be updated to the correct status later in the function.
+			rsp.Response = newHTTPResponse(req, http.StatusOK)
+		}
 	}
 
-	if rsp.Response == nil {
-		rsp.Response = newHTTPResponse(req, http.StatusOK)
-	}
+	// ErrorFilter tries to make sure there is as much information as possible to debug the fault.
+	// If for some reason the Request is not currently set (e.g. if it was lost by another Filter) then re-set it to req.
 	if rsp.Request == nil {
 		rsp.Request = &req
 	}
 
+	// If there is an error we want to turn it into a Terror on the response.
 	if rsp.Error != nil {
+		// We should be here if we hit one of the first two cases in this function.
+		// We could also be here if something weird happened e.g. an error was set and a 200 response was returned by the server.
 		if rsp.StatusCode == http.StatusOK {
 			// We got an error, but there is no error in the underlying response; marshal
 			if rsp.Body != nil {
@@ -81,6 +96,7 @@ func ErrorFilter(req Request, svc Service) Response {
 			rsp.Body = &bufCloser{}
 			terr := terrors.Wrap(rsp.Error, nil).(*terrors.Error)
 			rsp.Encode(terrors.Marshal(terr))
+			// We now set the status to the ACTUAL status code based on the Terror.
 			rsp.StatusCode = ErrorStatusCode(terr)
 			rsp.Header.Set("Terror", "1")
 		}
@@ -102,10 +118,12 @@ func ErrorFilter(req Request, svc Service) Response {
 		}
 	}
 
+	// If there was an error but the error string is empty re-write the error with the information we have.
 	if rsp.Error != nil && rsp.Error.Error() == "" {
 		if rsp.Response != nil {
 			rsp.Error = fmt.Errorf("Response error (%d)", rsp.StatusCode)
 		} else {
+			// We don't expect to ever hit this case right now.
 			rsp.Error = fmt.Errorf("Response error")
 		}
 	}


### PR DESCRIPTION
There is some non-obvious behavior inside `ErrorFilter` that we had to figure out whilst debugging an issue recently. We tried to document that.