### PR TITLE
Encoding / Decoding changes in protobuf branch

### DIFF
--- a/request.go
+++ b/request.go
@@ -41,10 +41,8 @@ func (r *Request) unwrappedContext() context.Context {
 	}
 }
 
-// Encode maps to to EncodeAsJSON
-// TODO: Remove in the next major release and require encoding to explicitly go through either EncodeAsJSON, EncodeAsProtoJSON or EncodeAsProtobuf
 func (r *Request) Encode(v interface{}) {
-	r.EncodeAsJSON(v)
+	r.EncodeAsProtobuf(v)
 }
 
 // EncodeAsJSON serialises the passed object as JSON into the body (and sets appropriate headers).

--- a/request.go
+++ b/request.go
@@ -41,8 +41,9 @@ func (r *Request) unwrappedContext() context.Context {
 	}
 }
 
+// Encode maps to to EncodeAsJSON
 func (r *Request) Encode(v interface{}) {
-	r.EncodeAsProtobuf(v)
+	r.EncodeAsJSON(v)
 }
 
 // EncodeAsJSON serialises the passed object as JSON into the body (and sets appropriate headers).

--- a/request.go
+++ b/request.go
@@ -134,21 +134,12 @@ func (r Request) Decode(v interface{}) error {
 		}
 		err = protojson.Unmarshal(b, m)
 
-	case "application/json", "text/json":
+	default:
 		m, ok := v.(proto.Message)
 		if !ok {
 			return terrors.InternalService("invalid_type", "could not decode proto message", nil)
 		}
 		err = json.Unmarshal(b, m)
-
-	default:
-		err = terrors.BadRequest(
-			terrors.ErrBadRequest,
-			"not a supported Content-Type",
-			map[string]string{
-				"Content-Type": r.Header.Get("Content-Type"),
-			},
-		)
 	}
 
 	return terrors.WrapWithCode(err, nil, terrors.ErrBadRequest)

--- a/request.go
+++ b/request.go
@@ -143,12 +143,12 @@ func (r Request) Decode(v interface{}) error {
 
 	default:
 		err = terrors.BadRequest(
-				terrors.ErrBadRequest,
-				"not a supported Content-Type",
-				map[string]string{
-					"Content-Type": r.Header.Get("Content-Type"),
-				},
-			)
+			terrors.ErrBadRequest,
+			"not a supported Content-Type",
+			map[string]string{
+				"Content-Type": r.Header.Get("Content-Type"),
+			},
+		)
 	}
 
 	return terrors.WrapWithCode(err, nil, terrors.ErrBadRequest)

--- a/request.go
+++ b/request.go
@@ -126,7 +126,7 @@ func (r Request) Decode(v interface{}) error {
 	// This is a backward compatibility break for those using google.golang.org/protobuf/proto.Message incorrectly.
 
 	// Older versions of typhon marshal/unmarshal using json, to prevent a regression, we only use protojson if the
-	// content-type hints that this message is protojson
+	// content-type explicitly declares that this message is protojson
 	case "application/jsonpb", "application/protojson":
 		m, ok := v.(proto.Message)
 		if !ok {

--- a/request.go
+++ b/request.go
@@ -146,7 +146,7 @@ func (r Request) Decode(v interface{}) error {
 				terrors.ErrBadRequest,
 				"not a supported Content-Type",
 				map[string]string{
-					"content-type": r.Header.Get("Content-Type"),
+					"Content-Type": r.Header.Get("Content-Type"),
 				},
 			)
 	}

--- a/request.go
+++ b/request.go
@@ -70,9 +70,24 @@ func (r *Request) EncodeAsJSON(v interface{}) {
 	r.Header.Set("Content-Type", "application/json")
 }
 
-// TODO: Add EncodeAsProtoJSON to replace EncodeAsJSON in a later version (this will break compatibility so needs to be a major release)
+// EncodeAsProtoJSON serialises the passed object as ProtoJSON into the body (and sets appropriate headers).
+func (r *Request) EncodeAsProtoJSON(m proto.Message) {
+	out, err := protojson.Marshal(m)
+	if err != nil {
+		r.err = terrors.Wrap(err, nil)
+		return
+	}
 
-// EncodeAsProtobuf serialises the passed object as protobuf into the body
+	n, err := r.Write(out)
+	if err != nil {
+		r.err = terrors.Wrap(err, nil)
+		return
+	}
+	r.Header.Set("Content-Type", "application/jsonpb")
+	r.ContentLength = int64(n)
+}
+
+// EncodeAsProtobuf serialises the passed object as protobuf into the body (and sets appropriate headers).
 func (r *Request) EncodeAsProtobuf(m proto.Message) {
 	out, err := proto.Marshal(m)
 	if err != nil {

--- a/request.go
+++ b/request.go
@@ -134,13 +134,23 @@ func (r Request) Decode(v interface{}) error {
 		}
 		err = protojson.Unmarshal(b, m)
 
-	default:
+	case "application/json", "text/json":
 		m, ok := v.(proto.Message)
 		if !ok {
 			return terrors.InternalService("invalid_type", "could not decode proto message", nil)
 		}
 		err = json.Unmarshal(b, m)
+
+	default:
+		err = terrors.BadRequest(
+				terrors.ErrBadRequest,
+				"not a supported Content-Type",
+				map[string]string{
+					"content-type": r.Header.Get("Content-Type"),
+				},
+			)
 	}
+
 	return terrors.WrapWithCode(err, nil, terrors.ErrBadRequest)
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -78,7 +78,7 @@ func TestRequestEncodeProtobuf(t *testing.T) {
 	req := NewRequest(nil, "GET", "/", nil)
 	req.EncodeAsProtobuf(g)
 
-	bodyBytes, err := req.BodyBytes(false)
+	bodyBytes, err := ioutil.ReadAll(req.Body)
 	require.NoError(t, err)
 
 	assert.Equal(t, "application/protobuf", req.Header.Get("Content-Type"))
@@ -98,7 +98,7 @@ func TestRequestEncodeJSON(t *testing.T) {
 	req := NewRequest(nil, "GET", "/", nil)
 	req.EncodeAsJSON(message)
 
-	bodyBytes, err := req.BodyBytes(false)
+	bodyBytes, err := ioutil.ReadAll(req.Body)
 	require.NoError(t, err)
 
 	assert.Equal(t, "application/json", req.Header.Get("Content-Type"))

--- a/request_test.go
+++ b/request_test.go
@@ -124,7 +124,11 @@ func jsonStreamMarshal(v interface{}) ([]byte, error) {
 	writer := bufio.NewWriter(&buffer)
 
 	err := json.NewEncoder(writer).Encode(v)
+	if err != nil {
+		return nil, err
+	}
 
+	err = writer.Flush()
 	if err != nil {
 		return nil, err
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -1,6 +1,7 @@
 package typhon
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -92,11 +93,11 @@ func TestRequestEncodeJSON(t *testing.T) {
 		"bar": 3,
 	}
 
-	jsonContentForComparison, err := json.Marshal(message)
+	jsonContentForComparison, err := jsonStreamMarshal(message)
 	require.NoError(t, err)
 
 	req := NewRequest(nil, "GET", "/", nil)
-	req.EncodeAsJSON(message)
+	req.Encode(message)
 
 	bodyBytes, err := ioutil.ReadAll(req.Body)
 	require.NoError(t, err)
@@ -115,4 +116,18 @@ func TestRequestSetMetadata(t *testing.T) {
 	req := NewRequest(ctx, "GET", "/", nil)
 
 	assert.Equal(t, []string{"data"}, req.Request.Header["meta"])
+}
+
+
+func jsonStreamMarshal(v interface{}) ([]byte, error) {
+	var buffer bytes.Buffer
+	writer := bufio.NewWriter(&buffer)
+
+	err := json.NewEncoder(writer).Encode(v)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
 }

--- a/response_test.go
+++ b/response_test.go
@@ -336,7 +336,7 @@ func TestResponseEncodeReader(t *testing.T) {
 	pm := &protoMarshalerReader{
 		ReadCloser: ioutil.NopCloser(strings.NewReader("this should never see the light of day")),
 		Greeting: &prototest.Greeting{
-			Message:  "hello",
+			Message: "hello",
 		},
 	}
 	assert.Implements(t, (*proto.Message)(nil), pm)


### PR DESCRIPTION
This PR does a few things:
1. In response to Daniel's comment on the protobuf PR [here](https://github.com/monzo/typhon/pull/127#discussion_r750562509), this makes Typhon use only regular JSON or protobufs
2. ~~Adds new EncodeAsProtoJSON to encode a message as protojson~~
3. Maps Encode to point at EncodeAsProtobuf
4. ~~Blocks requests with a non-standard content-type from Typhon~~