### PR TITLE
Make sure Encode and Decode functions return terrors errors

### DIFF
--- a/response.go
+++ b/response.go
@@ -184,6 +184,7 @@ func (r *Response) Decode(v interface{}) error {
 		err = json.Unmarshal(b, v)
 	}
 
+	err = terrors.WrapWithCode(err, nil, terrors.ErrBadRequest)
 	if err != nil {
 		r.Error = err
 	}


### PR DESCRIPTION
Some code internally expects these to always be terrors. Since that was the behaviour in the past for all errors, this PR replicates the same logic for consistency

Also includes tests to make sure we don't break this invariant