### PR TITLE
Support HTTP2 Prior Knowledge

### DIFF
--- a/e2e_http1_test.go
+++ b/e2e_http1_test.go
@@ -1,6 +1,7 @@
 package typhon
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"testing"
@@ -26,6 +27,10 @@ func (f http1Flavour) Proto() string {
 	return "HTTP/1.1"
 }
 
+func (f http1Flavour) Context() (context.Context, func()) {
+	return context.WithCancel(context.Background())
+}
+
 type http1TLSFlavour struct {
 	T    *testing.T
 	cert tls.Certificate
@@ -47,4 +52,8 @@ func (f http1TLSFlavour) URL(s *Server) string {
 
 func (f http1TLSFlavour) Proto() string {
 	return "HTTP/1.1"
+}
+
+func (f http1TLSFlavour) Context() (context.Context, func()) {
+	return context.WithCancel(context.Background())
 }


### PR DESCRIPTION
This PR rebases and builds on https://github.com/monzo/typhon/pull/121 to support HTTP2 Prior Knowledge using a context flag

Prior Knowledge connections are discussed in [section 3.4 of the HTTP/2 RFC](https://tools.ietf.org/html/rfc7540#section-3.4):

```
A client can learn that a particular server supports HTTP/2 by other
means.  For example, [ALT-SVC] describes a mechanism for advertising
this capability.

A client MUST send the connection preface (Section 3.5) and then MAY
immediately send HTTP/2 frames to such a server; servers can identify
these connections by the presence of the connection preface. This
only affects the establishment of HTTP/2 connections over cleartext
TCP; implementations that support HTTP/2 over TLS MUST use protocol
negotiation in TLS [TLS-ALPN].

Likewise, the server MUST send a connection preface (Section 3.5).

Without additional information, prior support for HTTP/2 is not a
strong signal that a given server will support HTTP/2 for future
connections.  For example, it is possible for server configurations
to change, for configurations to differ between instances in
clustered servers, or for network conditions to change.
```