### PR TITLE
Add basic circleci configuration for typhon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.17
+        working_directory: /go/src/github.com/monzo/typhon
+        resource_class: small # = 1 vCPU, 2GB RAM
+
+    steps:
+      - checkout
+      - run: |
+          go get -v golang.org/x/lint/golint
+      - run: go vet ./...
+      - run: golint .
+      - run: go test -v ./...
+      - run: go test -v -race ./...
+
+
+workflows:
+  version: 2
+  build-workflow:
+    jobs:
+      - build


### PR DESCRIPTION
I've based this on both the existing [`.travis.yml`](https://github.com/monzo/typhon/blob/master/.travis.yml) and [wearedev's  CircleCI setup](https://github.com/monzo/wearedev/blob/90cdffb637faa3325406810a857bb0821c147ed0/.circleci/config.yml). 

Granted, that's the easy part, and it's very much free as in puppy. I'm not currently sure about the `$PATH` is setup, so I think that the first build might fail because it can't find `golint`.