### PR TITLE
Log http2: stream closed as debug-level

### DIFF
--- a/http.go
+++ b/http.go
@@ -66,7 +66,8 @@ func copyErrSeverity(err error) slog.Severity {
 
 	switch {
 	case strings.HasSuffix(err.Error(), "read on closed response body"),
-		strings.HasSuffix(err.Error(), "connection reset by peer"):
+		strings.HasSuffix(err.Error(), "connection reset by peer"),
+		strings.HasSuffix(err.Error(), "http2: stream closed"):
 		return slog.DebugSeverity
 	}
 


### PR DESCRIPTION
We had some internal reports of services logging warnings like "Couldn't send response body", with the underlying error being "http2: stream closed".

These errors occur as a result of the client closing the stream as we're still writing to it, which is a frequent and expected part of HTTP/2 operation, so we can safely log these at debug level.