### PR TITLE
Add support for server timeouts

### DIFF
--- a/e2e_http1_test.go
+++ b/e2e_http1_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"testing"
+
 	"github.com/monzo/terrors"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 )

--- a/e2e_http1_test.go
+++ b/e2e_http1_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/monzo/terrors"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,8 +15,8 @@ type http1Flavour struct {
 	T *testing.T
 }
 
-func (f http1Flavour) Serve(svc Service) *Server {
-	s, err := Listen(svc, "localhost:0")
+func (f http1Flavour) Serve(svc Service, opts ...ServerOption) *Server {
+	s, err := Listen(svc, "localhost:0", opts...)
 	require.NoError(f.T, err)
 	return s
 }
@@ -31,17 +33,22 @@ func (f http1Flavour) Context() (context.Context, func()) {
 	return context.WithCancel(context.Background())
 }
 
+func (f http1Flavour) AssertConnectionResetError(t *testing.T, terr *terrors.Error) {
+	assert.Equal(t, terrors.ErrInternalService, terr.Code)
+	assert.Equal(t, "EOF", terr.Message)
+}
+
 type http1TLSFlavour struct {
 	T    *testing.T
 	cert tls.Certificate
 }
 
-func (f http1TLSFlavour) Serve(svc Service) *Server {
+func (f http1TLSFlavour) Serve(svc Service, opts ...ServerOption) *Server {
 	l, err := tls.Listen("tcp", "localhost:0", &tls.Config{
 		Certificates: []tls.Certificate{f.cert},
 		ClientAuth:   tls.NoClientCert})
 	require.NoError(f.T, err)
-	s, err := Serve(svc, l)
+	s, err := Serve(svc, l, opts...)
 	require.NoError(f.T, err)
 	return s
 }
@@ -56,4 +63,9 @@ func (f http1TLSFlavour) Proto() string {
 
 func (f http1TLSFlavour) Context() (context.Context, func()) {
 	return context.WithCancel(context.Background())
+}
+
+func (f http1TLSFlavour) AssertConnectionResetError(t *testing.T, terr *terrors.Error) {
+	assert.Equal(t, terrors.ErrInternalService, terr.Code)
+	assert.Equal(t, "local error: tls: bad record MAC", terr.Message)
 }

--- a/e2e_http2_test.go
+++ b/e2e_http2_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/monzo/terrors"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,9 +16,9 @@ type http2H2cFlavour struct {
 	client Service
 }
 
-func (f http2H2cFlavour) Serve(svc Service) *Server {
+func (f http2H2cFlavour) Serve(svc Service, opts ...ServerOption) *Server {
 	svc = svc.Filter(H2cFilter)
-	s, err := Listen(svc, "localhost:0")
+	s, err := Listen(svc, "localhost:0", opts...)
 	require.NoError(f.T, err)
 	return s
 }
@@ -33,14 +35,19 @@ func (f http2H2cFlavour) Context() (context.Context, func()) {
 	return context.WithCancel(context.Background())
 }
 
+func (f http2H2cFlavour) AssertConnectionResetError(t *testing.T, terr *terrors.Error) {
+	assert.Equal(t, terrors.ErrInternalService, terr.Code)
+	assert.Contains(t, terr.Message, "INTERNAL_ERROR")
+}
+
 type http2H2cPriorKnowledgeFlavour struct {
 	T      *testing.T
 	client Service
 }
 
-func (f http2H2cPriorKnowledgeFlavour) Serve(svc Service) *Server {
+func (f http2H2cPriorKnowledgeFlavour) Serve(svc Service, opts ...ServerOption) *Server {
 	svc = svc.Filter(H2cFilter)
-	s, err := Listen(svc, "localhost:0")
+	s, err := Listen(svc, "localhost:0", opts...)
 	require.NoError(f.T, err)
 	return s
 }
@@ -59,19 +66,24 @@ func (f http2H2cPriorKnowledgeFlavour) Context() (context.Context, func()) {
 	return ctx, cancel
 }
 
+func (f http2H2cPriorKnowledgeFlavour) AssertConnectionResetError(t *testing.T, terr *terrors.Error) {
+	assert.Equal(t, terrors.ErrInternalService, terr.Code)
+	assert.Equal(t, "EOF", terr.Message)
+}
+
 type http2H2Flavour struct {
 	T      *testing.T
 	client Service
 	cert   tls.Certificate
 }
 
-func (f http2H2Flavour) Serve(svc Service) *Server {
+func (f http2H2Flavour) Serve(svc Service, opts ...ServerOption) *Server {
 	l, err := tls.Listen("tcp", "localhost:0", &tls.Config{
 		Certificates: []tls.Certificate{f.cert},
 		ClientAuth:   tls.NoClientCert,
 		NextProtos:   []string{"h2"}})
 	require.NoError(f.T, err)
-	s, err := Serve(svc, l)
+	s, err := Serve(svc, l, opts...)
 	require.NoError(f.T, err)
 	return s
 }
@@ -86,4 +98,9 @@ func (f http2H2Flavour) Proto() string {
 
 func (f http2H2Flavour) Context() (context.Context, func()) {
 	return context.WithCancel(context.Background())
+}
+
+func (f http2H2Flavour) AssertConnectionResetError(t *testing.T, terr *terrors.Error) {
+	assert.Equal(t, terrors.ErrInternalService, terr.Code)
+	assert.Contains(t, terr.Message, "INTERNAL_ERROR")
 }

--- a/e2e_http2_test.go
+++ b/e2e_http2_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"testing"
+
 	"github.com/monzo/terrors"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/stretchr/testify/require"
 )

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -22,7 +22,7 @@ func main() {
 	svc := router.Serve().
 		Filter(typhon.ErrorFilter).
 		Filter(typhon.H2cFilter)
-	srv, err := typhon.Listen(svc, ":8000")
+	srv, err := typhon.Listen(svc, ":8000", typhon.WithTimeout(typhon.TimeoutOptions{Read: time.Second * 10}))
 	if err != nil {
 		panic(err)
 	}

--- a/h2c.go
+++ b/h2c.go
@@ -9,7 +9,7 @@ import (
 	"net/textproto"
 	"sync"
 
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	"github.com/monzo/terrors"
 	"golang.org/x/net/http/httpguts"
 	"golang.org/x/net/http2"

--- a/request_test.go
+++ b/request_test.go
@@ -5,11 +5,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/monzo/terrors"
 	"io/ioutil"
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/monzo/terrors"
 
 	legacyproto "github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"

--- a/response_test.go
+++ b/response_test.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	legacyproto "github.com/golang/protobuf/proto"
-	"github.com/monzo/typhon/legacyprototest"
 	"io"
 	"io/ioutil"
 	"math"
 	"net/http"
 	"strings"
 	"testing"
+
+	legacyproto "github.com/golang/protobuf/proto"
+	"github.com/monzo/typhon/legacyprototest"
 
 	"github.com/monzo/terrors"
 	"github.com/monzo/typhon/prototest"

--- a/server.go
+++ b/server.go
@@ -3,13 +3,14 @@ package typhon
 import (
 	"context"
 	"fmt"
-	"github.com/monzo/slog"
 	"net"
 	"net/http"
 	"os"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/monzo/slog"
 )
 
 type Server struct {


### PR DESCRIPTION
This allows configuring the standard Go http.Server timeouts on Typhon servers, and adds a new ServerOption interface that we can use to extend Typhon config in the future.

Sadly I couldn't get this working for h2c - this is due to a bug in Go where the original *http.Server configuration doesn't get propagated to h2c connections. See https://github.com/golang/go/issues/52868