### PR TITLE
error-filter: Propogate body read errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -106,7 +106,7 @@ func ErrorFilter(req Request, svc Service) Response {
 		b, err := rsp.BodyBytes(false)
 		if err != nil {
 			// Don't attempt to parse a partially read error response. Return the underlying read error when this occurs.
-			rsp.Error = terrors.Wrap(err, nil)
+			rsp.Error = terrors.NewInternalWithCause(err, "reading error response body", nil, "body_read_error")
 		} else {
 			switch rsp.Header.Get("Terror") {
 			case "1":


### PR DESCRIPTION
If we fail to read the entire body, we should propogate that error.

This will allow us to stop emitting this I/O error to Sentry.

Don't attempt to recover the partially read bytes - they might contain sensitive data, and putting them in a terror risks them being propogated to an unintended target.