### PR TITLE
Warn that BodyBytes functions should be called on reference

### DIFF
--- a/request.go
+++ b/request.go
@@ -158,6 +158,9 @@ func (r *Request) Write(b []byte) (n int, err error) {
 //
 // If consume is true, this is equivalent to ioutil.ReadAll; if false, the caller will observe the body to be in
 // the same state that it was before (ie. any remaining unread body can be read again).
+//
+// Warning: if consume is false, you must ensure this is called on a pointer receiver (*Request) and not a
+// Request value. This is because the Response.Body referenced by the caller needs to be mutated.
 func (r *Request) BodyBytes(consume bool) ([]byte, error) {
 	if consume {
 		defer r.Body.Close()

--- a/response.go
+++ b/response.go
@@ -249,6 +249,9 @@ func (r *Response) Write(b []byte) (n int, err error) {
 
 // BodyBytes fully reads the response body and returns the bytes read. If consume is false, the body is copied into a
 // new buffer such that it may be read again.
+//
+// Warning: if consume is false, you must ensure this is called on a pointer receiver (*Response) and not a
+// Response value. This is because the Response.Body referenced by the caller needs to be mutated.
 func (r *Response) BodyBytes(consume bool) ([]byte, error) {
 	if consume {
 		defer r.Body.Close()


### PR DESCRIPTION
We have been bitten by subtle bugs that are caused by this function being called on a value (and not a pointer to a value), combined with `consume == false`.