### PR TITLE
errors: export Status2TerrCode

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -49,7 +49,7 @@ func ErrorStatusCode(err error) int {
 }
 
 // terr2StatusCode converts HTTP status codes to a roughly equivalent terrors' code
-func status2TerrCode(code int) string {
+func Status2TerrCode(code int) string {
 	if c, ok := mapStatus2Terr[code]; ok {
 		return c
 	}


### PR DESCRIPTION
This PR exports the errors.Status2TerrCode function. It is currently unexported, and also unused.

I'd like to export this as it is useful for implementing custom error filters, for example, when using a Typhon client to talk to third-party APIs, it may be necessary to implement custom logic to deserialize the errors returned into Terrors. As part of that, it is common to translate the response HTTP status codes into Terror error codes. 

In our codebase, I can see around 15 re-implementations of this mapping, so I think there is sufficient usage for this change.