### PR TITLE
chore/deprecate ioutil

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"testing"
@@ -500,7 +499,7 @@ func TestE2EInfiniteContext(t *testing.T) {
 		require.NoError(t, rsp.Error)
 		assert.Equal(t, http.StatusOK, rsp.StatusCode)
 
-		b, err := ioutil.ReadAll(rsp.Body)
+		b, err := io.ReadAll(rsp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, "{\"b\":\"a\"}\n", string(b))
 
@@ -680,7 +679,7 @@ func TestE2EStreamingServerAbort(t *testing.T) {
 		req := NewRequest(ctx, "GET", flav.URL(s), nil)
 		rsp := req.Send().Response()
 		<-done
-		body, err := ioutil.ReadAll(rsp.Body)
+		body, err := io.ReadAll(rsp.Body)
 		assert.Equal(t, "derp\n", string(body))
 		assert.EqualError(t, err, io.ErrUnexpectedEOF.Error())
 	})
@@ -708,7 +707,7 @@ func TestE2EStreamingServerAbort(t *testing.T) {
 		req := NewRequest(ctx, "GET", flav.URL(s), nil)
 		rsp := req.Send().Response()
 		<-done
-		body, err := ioutil.ReadAll(rsp.Body)
+		body, err := io.ReadAll(rsp.Body)
 		assert.Equal(t, "derp\n", string(body))
 		require.IsType(t, http2.StreamError{}, err)
 		streamErr := err.(http2.StreamError)

--- a/request.go
+++ b/request.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -57,7 +56,7 @@ func (r *Request) EncodeAsJSON(v interface{}) {
 		r.ContentLength = -1
 		return
 	case io.Reader:
-		r.Body = ioutil.NopCloser(v)
+		r.Body = io.NopCloser(v)
 		r.ContentLength = -1
 		return
 	}
@@ -156,7 +155,7 @@ func (r *Request) Write(b []byte) (n int, err error) {
 
 // BodyBytes fully reads the request body and returns the bytes read.
 //
-// If consume is true, this is equivalent to ioutil.ReadAll; if false, the caller will observe the body to be in
+// If consume is true, this is equivalent to io.ReadAll; if false, the caller will observe the body to be in
 // the same state that it was before (ie. any remaining unread body can be read again).
 //
 // Warning: if consume is false, you must ensure this is called on a pointer receiver (*Request) and not a
@@ -164,7 +163,7 @@ func (r *Request) Write(b []byte) (n int, err error) {
 func (r *Request) BodyBytes(consume bool) ([]byte, error) {
 	if consume {
 		defer r.Body.Close()
-		return ioutil.ReadAll(r.Body)
+		return io.ReadAll(r.Body)
 	}
 
 	switch rc := r.Body.(type) {
@@ -176,7 +175,7 @@ func (r *Request) BodyBytes(consume bool) ([]byte, error) {
 		rdr := io.TeeReader(rc, buf)
 		// rc will never again be accessible: once it's copied it must be closed
 		defer rc.Close()
-		return ioutil.ReadAll(rdr)
+		return io.ReadAll(rdr)
 	}
 }
 

--- a/response.go
+++ b/response.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -41,7 +40,7 @@ func (r *Response) Encode(v interface{}) {
 		r.ContentLength = -1
 		return
 	case io.Reader:
-		r.Body = ioutil.NopCloser(v)
+		r.Body = io.NopCloser(v)
 		r.ContentLength = -1
 		return
 	}
@@ -255,7 +254,7 @@ func (r *Response) Write(b []byte) (n int, err error) {
 func (r *Response) BodyBytes(consume bool) ([]byte, error) {
 	if consume {
 		defer r.Body.Close()
-		return ioutil.ReadAll(r.Body)
+		return io.ReadAll(r.Body)
 	}
 
 	switch rc := r.Body.(type) {
@@ -268,7 +267,7 @@ func (r *Response) BodyBytes(consume bool) ([]byte, error) {
 		rdr := io.TeeReader(rc, buf)
 		// rc will never again be accessible: once it's copied it must be closed
 		defer rc.Close()
-		return ioutil.ReadAll(rdr)
+		return io.ReadAll(rdr)
 	}
 }
 

--- a/response_bench_test.go
+++ b/response_bench_test.go
@@ -2,7 +2,7 @@ package typhon
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -32,7 +32,7 @@ func BenchmarkResponseProtobufDecode(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rsp.Body = ioutil.NopCloser(bytes.NewReader(out))
+		rsp.Body = io.NopCloser(bytes.NewReader(out))
 		g := &prototest.Greeting{}
 		rsp.Decode(g)
 	}


### PR DESCRIPTION
Planned to use this repo in an RPC project and noticed multiple implementations of ioutil, which is deprecated.

Passes all - local - tests as ioutil functionality was migrated into the io package sometime ago.