### PR TITLE
Expose RouterPathPatternForRequest

### DIFF
--- a/router.go
+++ b/router.go
@@ -46,7 +46,8 @@ func RouterForRequest(r Request) *Router {
 	return nil
 }
 
-func routerPathPatternForRequest(r Request) string {
+// RouterPathPatternForRequest returns the path pattern this request matched to, or nil.
+func RouterPathPatternForRequest(r Request) string {
 	if v := r.Context.Value(routerRequestPatternContextKey); v != nil {
 		return v.(string)
 	}


### PR DESCRIPTION
This will allow us to extract the path pattern from a requests context, without having to go via the requests route. When used in client filters, the 'router' will not be set correctly, as the req will be outbound, but the context on the req will have preserved the original inbound requests context values.