### PR TITLE
fix: implement nil-safe Context methods on typhon.Request

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,11 +1,11 @@
 name: Run Tests
-on: 
+on:
   - pull_request
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.19.x, 1.23.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/request.go
+++ b/request.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	legacyproto "github.com/golang/protobuf/proto"
+	"github.com/monzo/terrors"
+	"google.golang.org/protobuf/proto"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
-
-	legacyproto "github.com/golang/protobuf/proto"
-	"github.com/monzo/terrors"
-	"google.golang.org/protobuf/proto"
+	"time"
 )
 
 // A Request is Typhon's wrapper around http.Request, used by both clients and servers.
@@ -261,4 +261,36 @@ func NewRequest(ctx context.Context, method, url string, body interface{}) Reque
 func NewRawRequest(ctx context.Context, method, url string, body io.ReadCloser) Request {
 	// as an io.ReadCloser, the body won't be encoded as JSON
 	return NewRequest(ctx, method, url, body)
+}
+
+// Deadline wraps the embedded context.Context method to return no deadline if the inner context is nil.
+func (r Request) Deadline() (time.Time, bool) {
+	if r.Context == nil {
+		return time.Time{}, false
+	}
+	return r.Context.Deadline()
+}
+
+// Done wraps the embedded context.Context method to return nil if the inner context is nil.
+func (r Request) Done() <-chan struct{} {
+	if r.Context == nil {
+		return nil
+	}
+	return r.Context.Done()
+}
+
+// Err wraps the embedded context.Context method to return nil if the inner context is nil.
+func (r Request) Err() error {
+	if r.Context == nil {
+		return nil
+	}
+	return r.Context.Err()
+}
+
+// Value wraps the embedded context.Context method to return a nil if the inner context is nil.
+func (r Request) Value(key any) any {
+	if r.Context == nil {
+		return nil
+	}
+	return r.Context.Value(key)
 }


### PR DESCRIPTION
While downstreaming a [new `slog` feature](https://github.com/monzo/slog/pull/22) to Monzo's internal monorepo, I discovered that the empty `typhon.Request` value panics when the various `context.Context` methods are called on it:

```go
typhon.Request{}.Value("foo") // panics
```

This happens because `typhon.Request` embeds `context.Context`, and so the zero value of `typhon.Request` has a typed nil context. This PR adds wrappers for the `context.Context` methods that behave like `context.Background()` on the empty `typhon.Request` value instead.

This is arguably not a bug: users of the library are expected to use either `typhon.NewRequest` or `typhon.NewRawRequest` to construct request values, these functions [explicitly handle the `nil` context case](https://github.com/monzo/typhon/blob/9796f7825e0a7c61b910d9bec98b54c20b5fa4ad/request.go#L236-L238), and the library makes no promises about the validity of the zero value.

Either way, we already have unit tests in our internal monorepo that build `typhon.Request` values manually and with the current `typhon.Request` implementation those tests are unstable: introducing a new call to one of the `context.Context` methods in a library (as I did in https://github.com/monzo/slog/pull/22), can indirectly cause consumers of that library to panic. It's not difficult to add wrapper methods that work correctly for the empty `typhon.Request` value, so that's exactly what this PR does.