### PR TITLE
chore: update CI to match minimum Go version declared in go.mod

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,11 +1,11 @@
 name: Run Tests
-on: 
+on:
   - pull_request
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.19.x, 1.23.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Factored out of https://github.com/monzo/typhon/pull/176.