### PR TITLE
Always close typhon response body when present

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -877,3 +877,28 @@ func TestE2EMaxConnectionAge_ConnectionAgeSet(t *testing.T) {
 		require.NotEmpty(t, connectionStart)
 	})
 }
+
+func TestE2EStatusCodesWithoutAResponseBody(t *testing.T) {
+	flavours(t, func(t *testing.T, flav e2eFlavour) {
+		ctx, cancel := flav.Context()
+		defer cancel()
+
+		svc := Service(func(req Request) Response {
+			response := req.Response([]byte("hello"))
+			response.Header.Set("content-type", "text/plain")
+			response.StatusCode = http.StatusNotModified // Not Modified
+			return response
+		})
+		svc = svc.Filter(ErrorFilter)
+		s := flav.Serve(svc)
+		defer s.Stop(context.Background())
+
+		req := NewRequest(ctx, "GET", flav.URL(s), nil)
+		rsp := req.Send().Response()
+		require.NoError(t, rsp.Error)
+		assert.Equal(t, http.StatusNotModified, rsp.StatusCode)
+		rspBody, err := rsp.BodyBytes(true)
+		require.NoError(t, err)
+		assert.Empty(t, rspBody)
+	})
+}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -878,15 +878,36 @@ func TestE2EMaxConnectionAge_ConnectionAgeSet(t *testing.T) {
 	})
 }
 
+type closeTrackingReadCloser struct {
+	inner    io.ReadCloser
+	isClosed *bool
+}
+
+func (c *closeTrackingReadCloser) Read(p []byte) (n int, err error) {
+	return c.inner.Read(p)
+}
+
+func (c *closeTrackingReadCloser) Close() error {
+	*c.isClosed = true
+	return c.inner.Close()
+}
+
 func TestE2EStatusCodesWithoutAResponseBody(t *testing.T) {
 	flavours(t, func(t *testing.T, flav e2eFlavour) {
 		ctx, cancel := flav.Context()
 		defer cancel()
 
+		responseBodyWasClosed := false
+
 		svc := Service(func(req Request) Response {
 			response := req.Response([]byte("hello"))
 			response.Header.Set("content-type", "text/plain")
 			response.StatusCode = http.StatusNotModified // Not Modified
+			oldBody := response.Body
+			response.Body = &closeTrackingReadCloser{
+				inner:    oldBody,
+				isClosed: &responseBodyWasClosed,
+			}
 			return response
 		})
 		svc = svc.Filter(ErrorFilter)
@@ -900,5 +921,6 @@ func TestE2EStatusCodesWithoutAResponseBody(t *testing.T) {
 		rspBody, err := rsp.BodyBytes(true)
 		require.NoError(t, err)
 		assert.Empty(t, rspBody)
+		assert.True(t, responseBodyWasClosed)
 	})
 }

--- a/http.go
+++ b/http.go
@@ -127,24 +127,26 @@ func HttpHandler(svc Service) http.Handler {
 			rwHeader[k] = v
 		}
 		rw.WriteHeader(rsp.StatusCode)
-		if rsp.Body != nil && bodyAllowedForStatus(rsp.StatusCode) {
-			defer rsp.Body.Close()
-			buf := *httpChunkBufPool.Get().(*[]byte)
-			defer httpChunkBufPool.Put(&buf)
-			if isStreamingRsp(rsp) {
-				// Streaming responses use copyChunked(), which takes care of flushing transparently
-				if _, err := copyChunked(rw, rsp.Body, buf); err != nil {
-					slog.Log(slog.Eventf(copyErrSeverity(err), req, "Couldn't send streaming response body", err))
+		if rsp.Body == nil || !bodyAllowedForStatus(rsp.StatusCode) {
+			return
+		}
 
-					// Prevent the client from accidentally consuming a truncated stream by aborting the response.
-					// The official way of interrupting an HTTP reply mid-stream is panic(http.ErrAbortHandler), which
-					// works for both HTTP/1.1 and HTTP.2. https://github.com/golang/go/issues/17790
-					panic(http.ErrAbortHandler)
-				}
-			} else {
-				if _, err := io.CopyBuffer(rw, rsp.Body, buf); err != nil {
-					slog.Log(slog.Eventf(copyErrSeverity(err), req, "Couldn't send response body", err))
-				}
+		defer rsp.Body.Close()
+		buf := *httpChunkBufPool.Get().(*[]byte)
+		defer httpChunkBufPool.Put(&buf)
+		if isStreamingRsp(rsp) {
+			// Streaming responses use copyChunked(), which takes care of flushing transparently
+			if _, err := copyChunked(rw, rsp.Body, buf); err != nil {
+				slog.Log(slog.Eventf(copyErrSeverity(err), req, "Couldn't send streaming response body", err))
+
+				// Prevent the client from accidentally consuming a truncated stream by aborting the response.
+				// The official way of interrupting an HTTP reply mid-stream is panic(http.ErrAbortHandler), which
+				// works for both HTTP/1.1 and HTTP.2. https://github.com/golang/go/issues/17790
+				panic(http.ErrAbortHandler)
+			}
+		} else {
+			if _, err := io.CopyBuffer(rw, rsp.Body, buf); err != nil {
+				slog.Log(slog.Eventf(copyErrSeverity(err), req, "Couldn't send response body", err))
 			}
 		}
 	})

--- a/http.go
+++ b/http.go
@@ -127,11 +127,16 @@ func HttpHandler(svc Service) http.Handler {
 			rwHeader[k] = v
 		}
 		rw.WriteHeader(rsp.StatusCode)
-		if rsp.Body == nil || !bodyAllowedForStatus(rsp.StatusCode) {
+		if rsp.Body == nil {
 			return
 		}
 
 		defer rsp.Body.Close()
+
+		if !bodyAllowedForStatus(rsp.StatusCode) {
+			return
+		}
+
 		buf := *httpChunkBufPool.Get().(*[]byte)
 		defer httpChunkBufPool.Put(&buf)
 		if isStreamingRsp(rsp) {

--- a/http.go
+++ b/http.go
@@ -117,9 +117,14 @@ func HttpHandler(svc Service) http.Handler {
 		}
 		rsp := svc(req)
 
-		// If the connection was hijacked, we should not attempt to write anything out
 		if rsp.hijacked {
 			return
+		}
+
+		// If the connection has been hijacked, the hijacker is responsible for any
+		// resource cleanup (as per http.Hijacker)
+		if rsp.Body != nil {
+			defer rsp.Body.Close()
 		}
 
 		rwHeader := rw.Header()
@@ -127,13 +132,7 @@ func HttpHandler(svc Service) http.Handler {
 			rwHeader[k] = v
 		}
 		rw.WriteHeader(rsp.StatusCode)
-		if rsp.Body == nil {
-			return
-		}
-
-		defer rsp.Body.Close()
-
-		if !bodyAllowedForStatus(rsp.StatusCode) {
+		if rsp.Body == nil || !bodyAllowedForStatus(rsp.StatusCode) {
 			return
 		}
 


### PR DESCRIPTION
Re: https://github.com/monzo/typhon/pull/153

We previously didn't close the response body if we weren't going to send a body over the wire. However, this could cause a resource leak when the response body requires a resource that can't be handled by the garbage collector (eg: a goroutine). 
This should fix that issue by slightly re-arranging the closure logic.

This changes the indentation slightly, so you'll want to [view it ignoring whitespace](https://github.com/monzo/typhon/pull/179/changes?w=1).